### PR TITLE
huskyの実行をfrontendディレクトリ配下にいる時のみにする

### DIFF
--- a/frontend/.husky/pre-commit
+++ b/frontend/.husky/pre-commit
@@ -1,5 +1,7 @@
 #!/bin/sh
 . "$(dirname "$0")/_/husky.sh"
 
-cd frontend
-yarn lint-staged
+if [[ "${GIT_PREFIX}" == frontend* ]]; then
+  cd frontend
+  yarn lint-staged
+fi


### PR DESCRIPTION
## 目的
* husky&lint-stagedで実行している内容はReactプロジェクト内のESLintとPrettierなのでRailsプロジェクトのファイルに対しては実行しないようにする