### PR TITLE
team_idにNOT NULL制約を設ける

### DIFF
--- a/app/controllers/api/auth/registrations_controller.rb
+++ b/app/controllers/api/auth/registrations_controller.rb
@@ -3,20 +3,29 @@
 class Api::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsController
   before_action :check_invitation_token, only: :create
 
-  def create
+  private
+
+  def build_resource
+    @resource            = resource_class.new(sign_up_params)
+    @resource.provider   = provider
+
+    # honor devise configuration for case_insensitive_keys
+    if resource_class.case_insensitive_keys.include?(:email)
+      @resource.email = sign_up_params[:email].try(:downcase)
+    else
+      @resource.email = sign_up_params[:email]
+    end
+
+    # 以下追記
     invitation_token = request.headers[:InvitationToken]
-    super do |resource|
-      if invitation_token.present?
-        team = Team.find_by!(invitation_token: invitation_token)
-        resource.team_id = team.id
-      else
-        @invitation_token = SecureRandom.urlsafe_base64
-        resource.create_team!(invitation_token: @invitation_token)
-      end
+    if invitation_token.present?
+      team = Team.find_by!(invitation_token: invitation_token)
+      @resource.team_id = team.id
+    else
+      @invitation_token = SecureRandom.urlsafe_base64
+      @resource.create_team!(invitation_token: @invitation_token)
     end
   end
-
-  private
 
   def render_create_success
     if Team.enabled?(resource_data["team_id"])

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,7 +1,7 @@
 # frozen_string_literal: true
 
 class User < ApplicationRecord
-  belongs_to :team, optional: true
+  belongs_to :team
   # Include default devise modules. Others available are:
   # :confirmable, :lockable, :timeoutable, :trackable and :omniauthable
   devise :database_authenticatable, :registerable,

--- a/db/migrate/20220202034155_change_columns_and_not_null_on_users.rb
+++ b/db/migrate/20220202034155_change_columns_and_not_null_on_users.rb
@@ -1,0 +1,5 @@
+class ChangeColumnsAndNotNullOnUsers < ActiveRecord::Migration[6.1]
+  def change
+    change_column_null :users, :team_id, false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2022_01_29_062309) do
+ActiveRecord::Schema.define(version: 2022_02_02_034155) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -40,7 +40,7 @@ ActiveRecord::Schema.define(version: 2022_01_29_062309) do
     t.json "tokens"
     t.datetime "created_at", precision: 6, null: false
     t.datetime "updated_at", precision: 6, null: false
-    t.bigint "team_id"
+    t.bigint "team_id", null: false
     t.index ["confirmation_token"], name: "index_users_on_confirmation_token", unique: true
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true


### PR DESCRIPTION
## 概要
* サービスの仕様上`team_id`はNULLになることがないので、より安全にするためにNOT NULL制約を設けた

## 元々NOT NULL制約を設けられていなかった理由
* devise-token-authのコントローラ上書きを`super do...end`を用いておこなっていたため`invitation_token`を`user`に設定する前に一度`user`が作成（`save`）されるという実装になっていた。
    * `super do...end`は`render_create_success`の直前に実行されるため
        * 参考：https://devise-token-auth.gitbook.io/devise-token-auth/usage/overrides#passing-blocks-to-controllers
    * そのためUserモデルに`belongs_to :team, optional: true`を設定する必要があり、`team_id`にNOT NULL制約をつけることができていなかった

## 解決方針
* `super do...end`で上書きするのではなく`build_resource`メソッドを上書きすることで`user`の`save`前に`invitation_token`をセットすることができるようになり、`belongs_to :team, optional: true`は不要となり、`team_id`にNOT NULL制約を付けることができるようになった。

