### PR TITLE
サインアップ周りのテストを作成

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -19,6 +19,10 @@ Style/NumericLiterals:
   Exclude:
     - spec/**/*
 
+RSpec/MultipleExpectations:
+  Exclude:
+    - spec/**/*
+
 AllCops:
   Exclude:
     - "**/templates/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -23,6 +23,18 @@ RSpec/MultipleExpectations:
   Exclude:
     - spec/**/*
 
+RSpec/ContextWording:
+  Exclude:
+    - spec/**/*
+
+RSpec/DescribedClass:
+  Exclude:
+    - spec/**/*
+
+RSpec/ExampleLength:
+  Exclude:
+    - spec/**/*
+
 AllCops:
   Exclude:
     - "**/templates/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -35,6 +35,10 @@ RSpec/ExampleLength:
   Exclude:
     - spec/**/*
 
+RSpec/NestedGroups:
+  Exclude:
+    - spec/**/*
+
 AllCops:
   Exclude:
     - "**/templates/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -15,6 +15,10 @@ Metrics/ClassLength:
   Exclude:
     - spec/**/*
 
+Style/NumericLiterals:
+  Exclude:
+    - spec/**/*
+
 AllCops:
   Exclude:
     - "**/templates/**/*"

--- a/app/controllers/api/auth/registrations_controller.rb
+++ b/app/controllers/api/auth/registrations_controller.rb
@@ -46,8 +46,7 @@ class Api::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsControl
   def check_invitation_token_and_team_capacity
     invitation_token = request.headers[:InvitationToken]
     return if invitation_token.empty?
-    team = Team.find_by(invitation_token: invitation_token)
-    render_create_error_token_invalid_or_team_capacity_reached if !team.invitation_token_valid? || team.capacity_reached?
+    render_create_error_token_invalid_or_team_capacity_reached if !Team.invitation_token_exists?(invitation_token) || Team.find_by(invitation_token: invitation_token).capacity_reached?
   end
 
   def render_create_error_token_invalid_or_team_capacity_reached

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -10,7 +10,7 @@ class Team < ApplicationRecord
     users.length == MAX_TEAM_MENBER_NUMBER
   end
 
-  def invitation_token_valid?
+  def self.invitation_token_exists?(invitation_token)
     Team.exists?(invitation_token: invitation_token)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,5 @@ class User < ApplicationRecord
   devise :database_authenticatable, :registerable,
          :recoverable, :rememberable, :validatable
   include DeviseTokenAuth::Concerns::User
+  validates :name, presence: true
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :team do
     invitation_token { 1234567890 }

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -2,6 +2,6 @@
 
 FactoryBot.define do
   factory :team do
-    invitation_token { 1234567890 }
+    invitation_token { 'm4h09q7GyI2pT6gM14XCvg' }
   end
 end

--- a/spec/factories/teams.rb
+++ b/spec/factories/teams.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :team do
+    invitation_token { 1234567890 }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :user do
     name { 'Alice' }

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,0 +1,16 @@
+FactoryBot.define do
+  factory :first_user, class: 'User' do
+    name { "first_user" }
+    email { "first_user@example.com" }
+    password { "testtest" }
+    association :team
+  end
+
+  # 2人目の場合はsave前にinvitation_tokenをもとにteamを紐づけるため新たにteamを作成しない
+  # そのため association :team の設定を外している
+  factory :second_user, class: 'User' do
+    name { "second_user" }
+    email { "second_user@example.com" }
+    password { "testtest" }
+  end
+end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,18 +1,18 @@
 # frozen_string_literal: true
 
 FactoryBot.define do
-  factory :first_user, class: 'User' do
-    name { 'first_user' }
-    email { 'first_user@example.com' }
+  factory :host_user, class: 'User' do
+    name { 'host_user' }
+    email { 'host_user@example.com' }
     password { 'testtest' }
     association :team
   end
 
-  # 2人目の場合はsave前にinvitation_tokenをもとにteamを紐づけるため新たにteamを作成しない
+  # 招待される側の場合はsave前にinvitation_tokenをもとにteamを紐づけるため新たにteamを作成しない
   # そのため association :team の設定を外している
-  factory :second_user, class: 'User' do
-    name { 'second_user' }
-    email { 'second_user@example.com' }
+  factory :guest_user, class: 'User' do
+    name { 'guest_user' }
+    email { 'guest_user@example.com' }
     password { 'testtest' }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,16 +1,18 @@
+# frozen_string_literal: true
+
 FactoryBot.define do
   factory :first_user, class: 'User' do
-    name { "first_user" }
-    email { "first_user@example.com" }
-    password { "testtest" }
+    name { 'first_user' }
+    email { 'first_user@example.com' }
+    password { 'testtest' }
     association :team
   end
 
   # 2人目の場合はsave前にinvitation_tokenをもとにteamを紐づけるため新たにteamを作成しない
   # そのため association :team の設定を外している
   factory :second_user, class: 'User' do
-    name { "second_user" }
-    email { "second_user@example.com" }
-    password { "testtest" }
+    name { 'second_user' }
+    email { 'second_user@example.com' }
+    password { 'testtest' }
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,18 +1,11 @@
-# frozen_string_literal: true
-
 FactoryBot.define do
-  factory :host_user, class: 'User' do
-    name { 'host_user' }
-    email { 'host_user@example.com' }
+  factory :user do
+    name { 'Alice' }
+    sequence(:email) { |n| "tester#{n}@example.com" }
     password { 'testtest' }
-    association :team
-  end
 
-  # 招待される側の場合はsave前にinvitation_tokenをもとにteamを紐づけるため新たにteamを作成しない
-  # そのため association :team の設定を外している
-  factory :guest_user, class: 'User' do
-    name { 'guest_user' }
-    email { 'guest_user@example.com' }
-    password { 'testtest' }
+    trait :with_team do
+      association :team
+    end
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -10,4 +10,9 @@ RSpec.describe Team, type: :model do
     guest_user.save
     expect(host_user.team.capacity_reached?).to be true
   end
+
+  example '1つのteamに含まれるユーザーが1人の時は満員ではない' do
+    host_user = create(:user, :with_team)
+    expect(host_user.team.capacity_reached?).to be false
+  end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -3,7 +3,7 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
-  it 'is available when including 2 users' do
+  example '1つのteamに含まれるユーザーが2人の時teamは有効な状態となる' do
     host_user = create(:user, :with_team)
     guest_user = build(:user)
     guest_user.team_id = host_user.team_id

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -8,6 +8,6 @@ RSpec.describe Team, type: :model do
     guest_user = build(:user)
     guest_user.team_id = host_user.team_id
     guest_user.save
-    expect(described_class.enabled?(host_user.team_id)).to be true
+    expect(Team.enabled?(host_user.team_id)).to be true
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,0 +1,11 @@
+require 'rails_helper'
+
+RSpec.describe Team, type: :model do
+  it "is available when including 2 users" do
+    first_user = create(:first_user)
+    second_user = build(:second_user)
+    second_user.team_id = first_user.team_id
+    second_user.save
+    expect(Team.enabled?(first_user.team_id)).to be true
+  end
+end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -4,8 +4,8 @@ require 'rails_helper'
 
 RSpec.describe Team, type: :model do
   it 'is available when including 2 users' do
-    host_user = create(:host_user)
-    guest_user = build(:guest_user)
+    host_user = create(:user, :with_team)
+    guest_user = build(:user)
     guest_user.team_id = host_user.team_id
     guest_user.save
     expect(described_class.enabled?(host_user.team_id)).to be true

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -3,11 +3,11 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
-  example '1つのteamに含まれるユーザーが2人の時teamは有効な状態となる' do
+  example '1つのteamに含まれるユーザーが2人の時満員となる' do
     host_user = create(:user, :with_team)
     guest_user = build(:user)
     guest_user.team_id = host_user.team_id
     guest_user.save
-    expect(Team.enabled?(host_user.team_id)).to be true
+    expect(host_user.team.capacity_reached?).to be true
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -4,10 +4,10 @@ require 'rails_helper'
 
 RSpec.describe Team, type: :model do
   it 'is available when including 2 users' do
-    first_user = create(:first_user)
-    second_user = build(:second_user)
-    second_user.team_id = first_user.team_id
-    second_user.save
-    expect(described_class.enabled?(first_user.team_id)).to be true
+    host_user = create(:host_user)
+    guest_user = build(:guest_user)
+    guest_user.team_id = host_user.team_id
+    guest_user.save
+    expect(described_class.enabled?(host_user.team_id)).to be true
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -1,11 +1,13 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
-  it "is available when including 2 users" do
+  it 'is available when including 2 users' do
     first_user = create(:first_user)
     second_user = build(:second_user)
     second_user.team_id = first_user.team_id
     second_user.save
-    expect(Team.enabled?(first_user.team_id)).to be true
+    expect(described_class.enabled?(first_user.team_id)).to be true
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,31 +4,31 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it 'is valid with a name, email, password and password confirmation' do
-    user = build(:host_user)
+    user = build(:user, :with_team)
     expect(user).to be_valid
   end
 
   it 'is invalid without a name' do
-    user = build(:host_user, name: nil)
+    user = build(:user, name: nil)
     user.valid?
     expect(user.errors[:name]).to include("can't be blank")
   end
 
   it 'is invalid without a email' do
-    user = build(:host_user, email: nil)
+    user = build(:user, email: nil)
     user.valid?
     expect(user.errors[:email]).to include("can't be blank")
   end
 
   it 'is invalid without a password' do
-    user = build(:host_user, password: nil)
+    user = build(:user, password: nil)
     user.valid?
     expect(user.errors[:password]).to include("can't be blank")
   end
 
   it 'is invalid duplicate email address' do
-    create(:host_user, email: 'alice@example.com')
-    user = build(:guest_user, email: 'alice@example.com')
+    create(:user, :with_team, email: 'alice@example.com')
+    user = build(:user, email: 'alice@example.com')
     user.valid?
     expect(user.errors[:email]).to include('has already been taken')
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,33 +1,35 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  it "is valid with a name, email, password and password confirmation" do
+  it 'is valid with a name, email, password and password confirmation' do
     user = build(:first_user)
     expect(user).to be_valid
   end
 
-  it "is invalid without a name" do
+  it 'is invalid without a name' do
     user = build(:first_user, name: nil)
     user.valid?
     expect(user.errors[:name]).to include("can't be blank")
   end
 
-  it "is invalid without a email" do
+  it 'is invalid without a email' do
     user = build(:first_user, email: nil)
     user.valid?
     expect(user.errors[:email]).to include("can't be blank")
   end
 
-  it "is invalid without a password" do
+  it 'is invalid without a password' do
     user = build(:first_user, password: nil)
     user.valid?
     expect(user.errors[:password]).to include("can't be blank")
   end
 
-  it "is invalid duplicate email address" do
-    create(:first_user, email: "alice@example.com")
-    user = build(:first_user, email: "alice@example.com")
+  it 'is invalid duplicate email address' do
+    create(:first_user, email: 'alice@example.com')
+    user = build(:first_user, email: 'alice@example.com')
     user.valid?
-    expect(user.errors[:email]).to include("has already been taken")
+    expect(user.errors[:email]).to include('has already been taken')
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   example '名前、メールアドレス、パスワードがあれば登録できる' do
-    user = build(:user, :with_team)
+    user = build(:user, :with_team, name: 'Alice', email: 'alice@example.com', password: 'testtest')
     expect(user).to be_valid
   end
 

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -4,31 +4,31 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   it 'is valid with a name, email, password and password confirmation' do
-    user = build(:first_user)
+    user = build(:host_user)
     expect(user).to be_valid
   end
 
   it 'is invalid without a name' do
-    user = build(:first_user, name: nil)
+    user = build(:host_user, name: nil)
     user.valid?
     expect(user.errors[:name]).to include("can't be blank")
   end
 
   it 'is invalid without a email' do
-    user = build(:first_user, email: nil)
+    user = build(:host_user, email: nil)
     user.valid?
     expect(user.errors[:email]).to include("can't be blank")
   end
 
   it 'is invalid without a password' do
-    user = build(:first_user, password: nil)
+    user = build(:host_user, password: nil)
     user.valid?
     expect(user.errors[:password]).to include("can't be blank")
   end
 
   it 'is invalid duplicate email address' do
-    create(:first_user, email: 'alice@example.com')
-    user = build(:first_user, email: 'alice@example.com')
+    create(:host_user, email: 'alice@example.com')
+    user = build(:guest_user, email: 'alice@example.com')
     user.valid?
     expect(user.errors[:email]).to include('has already been taken')
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -1,0 +1,33 @@
+require 'rails_helper'
+
+RSpec.describe User, type: :model do
+  it "is valid with a name, email, password and password confirmation" do
+    user = build(:first_user)
+    expect(user).to be_valid
+  end
+
+  it "is invalid without a name" do
+    user = build(:first_user, name: nil)
+    user.valid?
+    expect(user.errors[:name]).to include("can't be blank")
+  end
+
+  it "is invalid without a email" do
+    user = build(:first_user, email: nil)
+    user.valid?
+    expect(user.errors[:email]).to include("can't be blank")
+  end
+
+  it "is invalid without a password" do
+    user = build(:first_user, password: nil)
+    user.valid?
+    expect(user.errors[:password]).to include("can't be blank")
+  end
+
+  it "is invalid duplicate email address" do
+    create(:first_user, email: "alice@example.com")
+    user = build(:first_user, email: "alice@example.com")
+    user.valid?
+    expect(user.errors[:email]).to include("has already been taken")
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -11,18 +11,21 @@ RSpec.describe User, type: :model do
   example '名前がなければ登録できない' do
     user = build(:user, name: nil)
     user.valid?
+    expect(user).to be_invalid
     expect(user.errors[:name]).to include("can't be blank")
   end
 
   example 'メールアドレスがなければ登録できない' do
     user = build(:user, email: nil)
     user.valid?
+    expect(user).to be_invalid
     expect(user.errors[:email]).to include("can't be blank")
   end
 
   example 'パスワードがなければ登録できない' do
     user = build(:user, password: nil)
     user.valid?
+    expect(user).to be_invalid
     expect(user.errors[:password]).to include("can't be blank")
   end
 
@@ -30,6 +33,7 @@ RSpec.describe User, type: :model do
     create(:user, :with_team, email: 'alice@example.com')
     user = build(:user, email: 'alice@example.com')
     user.valid?
+    expect(user).to be_invalid
     expect(user.errors[:email]).to include('has already been taken')
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,30 +3,30 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  it 'is valid with a name, email, password and password confirmation' do
+  example '名前、メールアドレス、パスワードがあれば登録できる' do
     user = build(:user, :with_team)
     expect(user).to be_valid
   end
 
-  it 'is invalid without a name' do
+  example '名前がなければ登録できない' do
     user = build(:user, name: nil)
     user.valid?
     expect(user.errors[:name]).to include("can't be blank")
   end
 
-  it 'is invalid without a email' do
+  example 'メールアドレスがなければ登録できない' do
     user = build(:user, email: nil)
     user.valid?
     expect(user.errors[:email]).to include("can't be blank")
   end
 
-  it 'is invalid without a password' do
+  example 'パスワードがなければ登録できない' do
     user = build(:user, password: nil)
     user.valid?
     expect(user.errors[:password]).to include("can't be blank")
   end
 
-  it 'is invalid duplicate email address' do
+  example 'メールアドレスが重複していたら登録できない' do
     create(:user, :with_team, email: 'alice@example.com')
     user = build(:user, email: 'alice@example.com')
     user.valid?

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -63,4 +63,5 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+  config.include FactoryBot::Syntax::Methods
 end

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -26,12 +26,12 @@ RSpec.describe 'AuthApi', type: :request do
       example 'teamが新しく作られ、そのteamに所属するユーザーが作成される' do
         expect { execute_post }.to change(User, :count).by(1)
         user = User.find_by(email: 'charlie@example.com')
-        expect(user.team.invitation_token).not_to be_nil
+        expect(user.team.invitation_token).to be_present
       end
 
       example 'レスポンスにinvitation tokenが含まれる' do
         execute_post
-        expect(JSON.parse(response.body)['invitation_token']).not_to be_empty
+        expect(JSON.parse(response.body)['invitation_token']).to be_present
       end
     end
 

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -22,11 +22,7 @@ RSpec.describe 'AuthApi', type: :request do
       end
 
       example '新規登録するとユーザーに紐づくteamが新しく作られ、レスポンスにそのteamのinvitation_tokenが含まれる' do
-        expect {
-          post api_user_registration_path,
-          params: new_user_params,
-          headers: headers
-         }.to change(User, :count).by(1).and change(Team, :count).by(1)
+        expect { post api_user_registration_path, params: new_user_params, headers: headers }.to change(User, :count).by(1).and change(Team, :count).by(1)
         team = Team.last
         user = User.last
         expect(user.email).to eq 'charlie@example.com'
@@ -56,11 +52,7 @@ RSpec.describe 'AuthApi', type: :request do
       end
 
       example '新規登録すると新しいteamは作られず招待した人と同じteamに所属し、レスポンスにinvitation_tokenは含まれない' do
-        expect {
-          post api_user_registration_path,
-          params: new_user_params,
-          headers: headers
-         }.to change(User, :count).by(1).and change(Team, :count).by(0)
+        expect { post api_user_registration_path, params: new_user_params, headers: headers }.to change(User, :count).by(1).and change(Team, :count).by(0)
         guest_user = User.last
         expect(guest_user.email).to eq 'bob@example.com'
         expect(guest_user.team_id).to eq host_user.team_id

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -54,14 +54,11 @@ RSpec.describe 'AuthApi', type: :request do
         }
       end
 
-      example '招待した人と同じteamに所属するユーザーが作られる' do
-        expect { execute_post }.to change(User, :count).by(1)
-        guest_user = User.find_by(email: 'bob@example.com')
-        expect(host_user.team_id).to eq guest_user.team_id
-      end
-
-      example 'レスポンスにinvitation tokenが含まれない' do
-        execute_post
+      example '新規登録すると新しいteamは作られず招待した人と同じteamに所属し、レスポンスにinvitation_tokenは含まれない' do
+        expect { execute_post }.to change(User, :count).by(1).and change(Team, :count).by(0)
+        guest_user = User.last
+        expect(guest_user.email).to eq 'bob@example.com'
+        expect(guest_user.team_id).to eq host_user.team_id
         expect(JSON.parse(response.body)['invitation_token']).to be_empty
       end
     end

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -1,0 +1,47 @@
+require 'rails_helper'
+
+RSpec.describe "AuthApi", type: :request do
+  describe "POST api_user_registration_path" do
+    context "without invitation_token" do
+      it "creates a new user having a new team with invitation token" do
+        headers = {
+          'Content-Type'=>'application/json',
+          'Accept'=> 'application/json',
+          'InvitationToken'=> ''
+        }
+        expect {
+          post api_user_registration_path, params: {
+            name: 'charlie',
+            email: 'charlie@example.com',
+            password: 'testtest',
+            password_confirmation: 'testtest'
+          }.to_json, headers: headers
+        }.to change(User, :count).by(1)
+        user = User.find_by(email: 'charlie@example.com')
+        expect(user.team.invitation_token).not_to be_nil
+      end
+    end
+
+    context "with invitation_token" do
+      it 'creates a new user belongs to a team same with invitee' do
+        first_user = create(:first_user)
+        invitation_token = first_user.team.invitation_token
+        headers = {
+          'Content-Type'=>'application/json',
+          'Accept'=> 'application/json',
+          'InvitationToken'=> invitation_token
+        }
+        expect {
+          post api_user_registration_path, params: {
+            name: 'bob',
+            email: 'bob@example.com',
+            password: 'testtest',
+            password_confirmation: 'testtest'
+          }.to_json, headers: headers
+        }.to change(User, :count).by(1)
+        second_user = User.find_by(email: 'bob@example.com')
+        expect(first_user.team_id).to eq second_user.team_id
+      end
+    end
+  end
+end

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -39,7 +39,6 @@ RSpec.describe 'AuthApi', type: :request do
 
     context 'サインアップURLにinvitation_tokenが含まれる時' do
       let!(:host_user) { create(:user, :with_team) }
-      let!(:invitation_token) { host_user.team.invitation_token }
       let(:new_user_params) do
         {
           name: 'bob',
@@ -52,7 +51,7 @@ RSpec.describe 'AuthApi', type: :request do
         {
           'Content-Type' => 'application/json',
           'Accept' => 'application/json',
-          'InvitationToken' => invitation_token
+          'InvitationToken' => host_user.team.invitation_token
         }
       end
 

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -7,21 +7,21 @@ RSpec.describe 'AuthApi', type: :request do
     subject(:execute_post) { post api_user_registration_path, params: new_user_params, headers: headers }
 
     context 'without invitation_token' do
-      let(:headers) {
+      let(:headers) do
         {
           'Content-Type': 'application/json',
           Accept: 'application/json',
           InvitationToken: ''
         }
-      }
-      let(:new_user_params) {
+      end
+      let(:new_user_params) do
         {
           name: 'charlie',
           email: 'charlie@example.com',
           password: 'testtest',
           password_confirmation: 'testtest'
         }.to_json
-      }
+      end
 
       it 'creates a new user having a new team with invitation token' do
         expect { execute_post }.to change(User, :count).by(1)
@@ -38,21 +38,21 @@ RSpec.describe 'AuthApi', type: :request do
     context 'with invitation_token' do
       let!(:first_user) { create(:first_user) }
       let!(:invitation_token) { first_user.team.invitation_token }
-      let(:new_user_params) {
+      let(:new_user_params) do
         {
           name: 'bob',
           email: 'bob@example.com',
           password: 'testtest',
           password_confirmation: 'testtest'
         }.to_json
-      }
-      let(:headers) {
+      end
+      let(:headers) do
         {
           'Content-Type': 'application/json',
           Accept: 'application/json',
           InvitationToken: invitation_token
         }
-      }
+      end
 
       it 'creates a new user belongs to a team same with invitee' do
         expect { execute_post }.to change(User, :count).by(1)

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -65,18 +65,20 @@ RSpec.describe 'AuthApi', type: :request do
 
       context '異常系' do
         example '存在しないinvitation_tokenの場合登録できない' do
-          expect { post api_user_registration_path, params: new_user_params, headers: {
-            'Content-Type' => 'application/json',
-            'Accept' => 'application/json',
-            'InvitationToken' => '123456789'
-          } }.to change(User, :count).by(0).and change(Team, :count).by(0)
+          expect do
+            post api_user_registration_path, params: new_user_params, headers: {
+              'Content-Type' => 'application/json',
+              'Accept' => 'application/json',
+              'InvitationToken' => '123456789'
+            }
+          end.to change(User, :count).by(0).and change(Team, :count).by(0)
           expect(JSON.parse(response.body)['errors']['fullMessages']).to include('Your token is invalid or the team reached capacity')
         end
 
         example 'teamに既に2人のユーザーが所属していたら登録できない' do
-          guest_user_1 = build(:user)
-          guest_user_1.team_id = host_user.team_id
-          guest_user_1.save
+          guest_user = build(:user)
+          guest_user.team_id = host_user.team_id
+          guest_user.save
           expect { post api_user_registration_path, params: new_user_params, headers: headers }.to change(User, :count).by(0).and change(Team, :count).by(0)
           expect(JSON.parse(response.body)['errors']['fullMessages']).to include('Your token is invalid or the team reached capacity')
         end

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -1,77 +1,67 @@
+# frozen_string_literal: true
+
 require 'rails_helper'
 
-RSpec.describe "AuthApi", type: :request do
-  describe "POST api_user_registration_path" do
-    context "without invitation_token" do
-      it "creates a new user having a new team with invitation token" do
-        headers = {
-          'Content-Type'=>'application/json',
-          'Accept'=> 'application/json',
-          'InvitationToken'=> ''
-        }
-        expect {
-          post api_user_registration_path, params: {
-            name: 'charlie',
-            email: 'charlie@example.com',
-            password: 'testtest',
-            password_confirmation: 'testtest'
-          }.to_json, headers: headers
-        }.to change(User, :count).by(1)
-        user = User.find_by(email: 'charlie@example.com')
-        expect(user.team.invitation_token).not_to be_nil
-      end
+RSpec.describe 'AuthApi', type: :request do
+  describe 'POST api_user_registration_path' do
+    subject(:execute_post) { post api_user_registration_path, params: new_user_params, headers: headers }
 
-      it "returns json including invitation token" do
-        headers = {
-          'Content-Type'=>'application/json',
-          'Accept'=> 'application/json',
-          'InvitationToken'=> ''
+    context 'without invitation_token' do
+      let(:headers) {
+        {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          InvitationToken: ''
         }
-        post api_user_registration_path, params: {
+      }
+      let(:new_user_params) {
+        {
           name: 'charlie',
           email: 'charlie@example.com',
           password: 'testtest',
           password_confirmation: 'testtest'
-        }.to_json, headers: headers
+        }.to_json
+      }
+
+      it 'creates a new user having a new team with invitation token' do
+        expect { execute_post }.to change(User, :count).by(1)
+        user = User.find_by(email: 'charlie@example.com')
+        expect(user.team.invitation_token).not_to be_nil
+      end
+
+      it 'returns json including invitation token' do
+        execute_post
         expect(JSON.parse(response.body)['invitation_token']).not_to be_empty
       end
     end
 
-    context "with invitation_token" do
-      it 'creates a new user belongs to a team same with invitee' do
-        first_user = create(:first_user)
-        invitation_token = first_user.team.invitation_token
-        headers = {
-          'Content-Type'=>'application/json',
-          'Accept'=> 'application/json',
-          'InvitationToken'=> invitation_token
-        }
-        expect {
-          post api_user_registration_path, params: {
-            name: 'bob',
-            email: 'bob@example.com',
-            password: 'testtest',
-            password_confirmation: 'testtest'
-          }.to_json, headers: headers
-        }.to change(User, :count).by(1)
-        second_user = User.find_by(email: 'bob@example.com')
-        expect(first_user.team_id).to eq second_user.team_id
-      end
-
-      it "returns json including empty invitation token" do
-        first_user = create(:first_user)
-        invitation_token = first_user.team.invitation_token
-        headers = {
-          'Content-Type'=>'application/json',
-          'Accept'=> 'application/json',
-          'InvitationToken'=> invitation_token
-        }
-        post api_user_registration_path, params: {
+    context 'with invitation_token' do
+      let!(:first_user) { create(:first_user) }
+      let!(:invitation_token) { first_user.team.invitation_token }
+      let(:new_user_params) {
+        {
           name: 'bob',
           email: 'bob@example.com',
           password: 'testtest',
           password_confirmation: 'testtest'
-        }.to_json, headers: headers
+        }.to_json
+      }
+      let(:headers) {
+        {
+          'Content-Type': 'application/json',
+          Accept: 'application/json',
+          InvitationToken: invitation_token
+        }
+      }
+
+      it 'creates a new user belongs to a team same with invitee' do
+        expect { execute_post }.to change(User, :count).by(1)
+        second_user = User.find_by(email: 'bob@example.com')
+        expect(first_user.team_id).to eq second_user.team_id
+      end
+
+      it 'returns json including empty invitation token' do
+        execute_post
         expect(JSON.parse(response.body)['invitation_token']).to be_empty
       end
     end

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -21,15 +21,17 @@ RSpec.describe 'AuthApi', type: :request do
         }.to_json
       end
 
-      example '新規登録するとユーザーに紐づくteamが新しく作られ、レスポンスにそのteamのinvitation_tokenが含まれる' do
-        expect { post api_user_registration_path, params: new_user_params, headers: headers }.to change(User, :count).by(1).and change(Team, :count).by(1)
-        team = Team.last
-        user = User.last
-        expect(user.email).to eq 'charlie@example.com'
-        expect(user.team_id).to eq team.id
-        expect(user.team.invitation_token).to be_present
-        expect(JSON.parse(response.body)['invitation_token']).to be_present
-        expect(JSON.parse(response.body)['invitation_token']).to eq user.team.invitation_token
+      context '正常系' do
+        example 'ユーザーに紐づくteamが新しく作られ、レスポンスにそのteamのinvitation_tokenが含まれる' do
+          expect { post api_user_registration_path, params: new_user_params, headers: headers }.to change(User, :count).by(1).and change(Team, :count).by(1)
+          team = Team.last
+          user = User.last
+          expect(user.email).to eq 'charlie@example.com'
+          expect(user.team_id).to eq team.id
+          expect(user.team.invitation_token).to be_present
+          expect(JSON.parse(response.body)['invitation_token']).to be_present
+          expect(JSON.parse(response.body)['invitation_token']).to eq user.team.invitation_token
+        end
       end
     end
 
@@ -51,12 +53,14 @@ RSpec.describe 'AuthApi', type: :request do
         }
       end
 
-      example '新規登録すると新しいteamは作られず招待した人と同じteamに所属し、レスポンスにinvitation_tokenは含まれない' do
-        expect { post api_user_registration_path, params: new_user_params, headers: headers }.to change(User, :count).by(1).and change(Team, :count).by(0)
-        guest_user = User.last
-        expect(guest_user.email).to eq 'bob@example.com'
-        expect(guest_user.team_id).to eq host_user.team_id
-        expect(JSON.parse(response.body)['invitation_token']).to be_empty
+      context '正常系' do
+        example '新しいteamは作られず招待した人と同じteamに所属し、レスポンスにinvitation_tokenは含まれない' do
+          expect { post api_user_registration_path, params: new_user_params, headers: headers }.to change(User, :count).by(1).and change(Team, :count).by(0)
+          guest_user = User.last
+          expect(guest_user.email).to eq 'bob@example.com'
+          expect(guest_user.team_id).to eq host_user.team_id
+          expect(JSON.parse(response.body)['invitation_token']).to be_empty
+        end
       end
     end
   end

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -9,9 +9,9 @@ RSpec.describe 'AuthApi', type: :request do
     context 'サインアップURLにinvitation_tokenが含まれない時' do
       let(:headers) do
         {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-          InvitationToken: ''
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json',
+          'InvitationToken' => ''
         }
       end
       let(:new_user_params) do
@@ -48,9 +48,9 @@ RSpec.describe 'AuthApi', type: :request do
       end
       let(:headers) do
         {
-          'Content-Type': 'application/json',
-          Accept: 'application/json',
-          InvitationToken: invitation_token
+          'Content-Type' => 'application/json',
+          'Accept' => 'application/json',
+          'InvitationToken' => invitation_token
         }
       end
 

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -4,8 +4,6 @@ require 'rails_helper'
 
 RSpec.describe 'AuthApi', type: :request do
   describe 'POST api_user_registration_path' do
-    subject(:execute_post) { post api_user_registration_path, params: new_user_params, headers: headers }
-
     context 'サインアップURLにinvitation_tokenが含まれない時' do
       let(:headers) do
         {
@@ -24,7 +22,11 @@ RSpec.describe 'AuthApi', type: :request do
       end
 
       example '新規登録するとユーザーに紐づくteamが新しく作られ、レスポンスにそのteamのinvitation_tokenが含まれる' do
-        expect { execute_post }.to change(User, :count).by(1).and change(Team, :count).by(1)
+        expect {
+          post api_user_registration_path,
+          params: new_user_params,
+          headers: headers
+         }.to change(User, :count).by(1).and change(Team, :count).by(1)
         team = Team.last
         user = User.last
         expect(user.email).to eq 'charlie@example.com'
@@ -55,7 +57,11 @@ RSpec.describe 'AuthApi', type: :request do
       end
 
       example '新規登録すると新しいteamは作られず招待した人と同じteamに所属し、レスポンスにinvitation_tokenは含まれない' do
-        expect { execute_post }.to change(User, :count).by(1).and change(Team, :count).by(0)
+        expect {
+          post api_user_registration_path,
+          params: new_user_params,
+          headers: headers
+         }.to change(User, :count).by(1).and change(Team, :count).by(0)
         guest_user = User.last
         expect(guest_user.email).to eq 'bob@example.com'
         expect(guest_user.team_id).to eq host_user.team_id

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -20,6 +20,21 @@ RSpec.describe "AuthApi", type: :request do
         user = User.find_by(email: 'charlie@example.com')
         expect(user.team.invitation_token).not_to be_nil
       end
+
+      it "returns json including invitation token" do
+        headers = {
+          'Content-Type'=>'application/json',
+          'Accept'=> 'application/json',
+          'InvitationToken'=> ''
+        }
+        post api_user_registration_path, params: {
+          name: 'charlie',
+          email: 'charlie@example.com',
+          password: 'testtest',
+          password_confirmation: 'testtest'
+        }.to_json, headers: headers
+        expect(JSON.parse(response.body)['invitation_token']).not_to be_empty
+      end
     end
 
     context "with invitation_token" do
@@ -41,6 +56,23 @@ RSpec.describe "AuthApi", type: :request do
         }.to change(User, :count).by(1)
         second_user = User.find_by(email: 'bob@example.com')
         expect(first_user.team_id).to eq second_user.team_id
+      end
+
+      it "returns json including empty invitation token" do
+        first_user = create(:first_user)
+        invitation_token = first_user.team.invitation_token
+        headers = {
+          'Content-Type'=>'application/json',
+          'Accept'=> 'application/json',
+          'InvitationToken'=> invitation_token
+        }
+        post api_user_registration_path, params: {
+          name: 'bob',
+          email: 'bob@example.com',
+          password: 'testtest',
+          password_confirmation: 'testtest'
+        }.to_json, headers: headers
+        expect(JSON.parse(response.body)['invitation_token']).to be_empty
       end
     end
   end

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -36,7 +36,7 @@ RSpec.describe 'AuthApi', type: :request do
     end
 
     context 'with invitation_token' do
-      let!(:host_user) { create(:host_user) }
+      let!(:host_user) { create(:user, :with_team) }
       let!(:invitation_token) { host_user.team.invitation_token }
       let(:new_user_params) do
         {

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -36,8 +36,8 @@ RSpec.describe 'AuthApi', type: :request do
     end
 
     context 'with invitation_token' do
-      let!(:first_user) { create(:first_user) }
-      let!(:invitation_token) { first_user.team.invitation_token }
+      let!(:host_user) { create(:host_user) }
+      let!(:invitation_token) { host_user.team.invitation_token }
       let(:new_user_params) do
         {
           name: 'bob',
@@ -54,10 +54,10 @@ RSpec.describe 'AuthApi', type: :request do
         }
       end
 
-      it 'creates a new user belongs to a team same with invitee' do
+      it 'creates a new user belongs to a team same with host user' do
         expect { execute_post }.to change(User, :count).by(1)
-        second_user = User.find_by(email: 'bob@example.com')
-        expect(first_user.team_id).to eq second_user.team_id
+        guest_user = User.find_by(email: 'bob@example.com')
+        expect(host_user.team_id).to eq guest_user.team_id
       end
 
       it 'returns json including empty invitation token' do

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -23,15 +23,15 @@ RSpec.describe 'AuthApi', type: :request do
         }.to_json
       end
 
-      example 'teamが新しく作られ、そのteamに所属するユーザーが作成される' do
-        expect { execute_post }.to change(User, :count).by(1)
-        user = User.find_by(email: 'charlie@example.com')
+      example '新規登録するとユーザーに紐づくteamが新しく作られ、レスポンスにそのteamのinvitation_tokenが含まれる' do
+        expect { execute_post }.to change(User, :count).by(1).and change(Team, :count).by(1)
+        team = Team.last
+        user = User.last
+        expect(user.email).to eq 'charlie@example.com'
+        expect(user.team_id).to eq team.id
         expect(user.team.invitation_token).to be_present
-      end
-
-      example 'レスポンスにinvitation tokenが含まれる' do
-        execute_post
         expect(JSON.parse(response.body)['invitation_token']).to be_present
+        expect(JSON.parse(response.body)['invitation_token']).to eq user.team.invitation_token
       end
     end
 

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -62,6 +62,25 @@ RSpec.describe 'AuthApi', type: :request do
           expect(JSON.parse(response.body)['invitation_token']).to be_empty
         end
       end
+
+      context '異常系' do
+        example '存在しないinvitation_tokenの場合登録できない' do
+          expect { post api_user_registration_path, params: new_user_params, headers: {
+            'Content-Type' => 'application/json',
+            'Accept' => 'application/json',
+            'InvitationToken' => '123456789'
+          } }.to change(User, :count).by(0).and change(Team, :count).by(0)
+          expect(JSON.parse(response.body)['errors']['fullMessages']).to include('Your token is invalid or the team reached capacity')
+        end
+
+        example 'teamに既に2人のユーザーが所属していたら登録できない' do
+          guest_user_1 = build(:user)
+          guest_user_1.team_id = host_user.team_id
+          guest_user_1.save
+          expect { post api_user_registration_path, params: new_user_params, headers: headers }.to change(User, :count).by(0).and change(Team, :count).by(0)
+          expect(JSON.parse(response.body)['errors']['fullMessages']).to include('Your token is invalid or the team reached capacity')
+        end
+      end
     end
   end
 end

--- a/spec/requests/auth_api_spec.rb
+++ b/spec/requests/auth_api_spec.rb
@@ -6,7 +6,7 @@ RSpec.describe 'AuthApi', type: :request do
   describe 'POST api_user_registration_path' do
     subject(:execute_post) { post api_user_registration_path, params: new_user_params, headers: headers }
 
-    context 'without invitation_token' do
+    context 'サインアップURLにinvitation_tokenが含まれない時' do
       let(:headers) do
         {
           'Content-Type': 'application/json',
@@ -23,19 +23,19 @@ RSpec.describe 'AuthApi', type: :request do
         }.to_json
       end
 
-      it 'creates a new user having a new team with invitation token' do
+      example 'teamが新しく作られ、そのteamに所属するユーザーが作成される' do
         expect { execute_post }.to change(User, :count).by(1)
         user = User.find_by(email: 'charlie@example.com')
         expect(user.team.invitation_token).not_to be_nil
       end
 
-      it 'returns json including invitation token' do
+      example 'レスポンスにinvitation tokenが含まれる' do
         execute_post
         expect(JSON.parse(response.body)['invitation_token']).not_to be_empty
       end
     end
 
-    context 'with invitation_token' do
+    context 'サインアップURLにinvitation_tokenが含まれる時' do
       let!(:host_user) { create(:user, :with_team) }
       let!(:invitation_token) { host_user.team.invitation_token }
       let(:new_user_params) do
@@ -54,13 +54,13 @@ RSpec.describe 'AuthApi', type: :request do
         }
       end
 
-      it 'creates a new user belongs to a team same with host user' do
+      example '招待した人と同じteamに所属するユーザーが作られる' do
         expect { execute_post }.to change(User, :count).by(1)
         guest_user = User.find_by(email: 'bob@example.com')
         expect(host_user.team_id).to eq guest_user.team_id
       end
 
-      it 'returns json including empty invitation token' do
+      example 'レスポンスにinvitation tokenが含まれない' do
         execute_post
         expect(JSON.parse(response.body)['invitation_token']).to be_empty
       end


### PR DESCRIPTION
## やったこと
* モデルスペックの作成
    * User
    * Team
* リクエストスペックの作成
    * auth api

## ここで対応していないこと
* フロントエンドのテストは調査中なのでここではバックエンドのテストのみとします

## アプリの仕様について
* 二人で使用するアプリです
* 一人目のユーザーが会員登録を行うと招待用のURLが発行されます
* 二人目のユーザーは招待用のURLから会員登録を行うことで招待した人との紐付けが行われます

### アプリ概要詳細
https://bootcamp.fjord.jp/products/9767

### ER図
![image](https://user-images.githubusercontent.com/52844263/152629675-c85de155-0096-4700-ac8c-ec5dcb138dba.png)

https://github.com/mami-inuzuka/seppanda/issues/6#issuecomment-956002706