### PR TITLE
teamに既に2人ユーザーが所属している場合にそのteamに登録できないようにする

### DIFF
--- a/app/controllers/api/auth/registrations_controller.rb
+++ b/app/controllers/api/auth/registrations_controller.rb
@@ -28,15 +28,15 @@ class Api::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsControl
   end
 
   def render_create_success
-    if Team.enabled?(resource_data["team_id"])
+    if @resource.team.capacity_reached?
       render json: {
-        is_team_enabled: true,
+        is_team_capacity_reached: true,
         data:   resource_data,
         invitation_token: ''
       }
     else
       render json: {
-        is_team_enabled: false,
+        is_team_capacity_reached: false,
         data:   resource_data,
         invitation_token: @invitation_token
       }

--- a/app/controllers/api/auth/registrations_controller.rb
+++ b/app/controllers/api/auth/registrations_controller.rb
@@ -47,15 +47,15 @@ class Api::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsControl
     invitation_token = request.headers[:InvitationToken]
     return if invitation_token.empty?
     team = Team.find_by(invitation_token: invitation_token)
-    render_create_error_token_invalid if !team.invitation_token_valid? || team.capacity_reached?
+    render_create_error_token_invalid_or_team_capacity_reached if !team.invitation_token_valid? || team.capacity_reached?
   end
 
-  def render_create_error_token_invalid
+  def render_create_error_token_invalid_or_team_capacity_reached
     render json: {
       status: 'error',
       data:   resource_data,
       errors: {
-        fullMessages: [I18n.t('devise_token_auth.registrations.token_invalid_or_team_reached_capacity')]
+        fullMessages: [I18n.t('devise_token_auth.registrations.token_invalid_or_team_capacity_reached')]
       }
     }, status: 422
   end

--- a/app/controllers/api/auth/registrations_controller.rb
+++ b/app/controllers/api/auth/registrations_controller.rb
@@ -46,7 +46,8 @@ class Api::Auth::RegistrationsController < DeviseTokenAuth::RegistrationsControl
   def check_invitation_token_and_team_capacity
     invitation_token = request.headers[:InvitationToken]
     return if invitation_token.empty?
-    render_create_error_token_invalid if !Team.invitation_token_valid?(invitation_token) || Team.find_by(invitation_token: invitation_token).capacity_reached?
+    team = Team.find_by(invitation_token: invitation_token)
+    render_create_error_token_invalid if !team.invitation_token_valid? || team.capacity_reached?
   end
 
   def render_create_error_token_invalid

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -6,8 +6,8 @@ class Team < ApplicationRecord
   # 現在は1teamにつき2人まで登録できるようにする
   MAX_TEAM_MENBER_NUMBER = 2
 
-  def self.enabled?(id)
-    find(id).users.length == MAX_TEAM_MENBER_NUMBER
+  def capacity_reached?
+    users.length == MAX_TEAM_MENBER_NUMBER
   end
 
   def self.invitation_token_valid?(invitation_token)

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -10,7 +10,7 @@ class Team < ApplicationRecord
     users.length == MAX_TEAM_MENBER_NUMBER
   end
 
-  def self.invitation_token_valid?(invitation_token)
-    exists?(invitation_token: invitation_token)
+  def invitation_token_valid?
+    Team.exists?(invitation_token: invitation_token)
   end
 end

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -65,5 +65,4 @@ en:
         other: "%{count} errors prohibited this %{resource} from being saved:"
   devise_token_auth:
     registrations:
-      token_invalid: "Your token is invalid"
-      team_capacity_reached: "The team reached capacity"
+      token_invalid_or_team_reached_capacity: "Your token is invalid or the team reached capacity"

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -65,4 +65,4 @@ en:
         other: "%{count} errors prohibited this %{resource} from being saved:"
   devise_token_auth:
     registrations:
-      token_invalid_or_team_reached_capacity: "Your token is invalid or the team reached capacity"
+      token_invalid_or_team_capacity_reached: "Your token is invalid or the team reached capacity"

--- a/config/locales/devise.en.yml
+++ b/config/locales/devise.en.yml
@@ -66,3 +66,4 @@ en:
   devise_token_auth:
     registrations:
       token_invalid: "Your token is invalid"
+      team_capacity_reached: "The team reached capacity"

--- a/frontend/src/components/pages/SignUp.tsx
+++ b/frontend/src/components/pages/SignUp.tsx
@@ -48,7 +48,7 @@ export const SignUp: VFC = memo(() => {
         Cookies.set('_uid', res.headers.uid, { secure: true })
         setIsSignedIn(true)
         // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
-        if (res.data.isTeamEnabled) {
+        if (res.data.isTeamCapacityReached) {
           history.push('/')
         } else {
           history.push({

--- a/frontend/src/types/signUpResponse.ts
+++ b/frontend/src/types/signUpResponse.ts
@@ -3,5 +3,5 @@ import { User } from './user'
 export type SignUpResponse = {
   data: User
   invitationToken: string
-  isTeamEnabled: boolean
+  isTeamCapacityReached: boolean
 }


### PR DESCRIPTION
## 変更背景
新規ユーザーの登録時にteamが定員に達しているかどうかを確認する処理がはいっていなかったため、一つのteamに三人以上所属できるようになってしまっていた。

一つのteamには二人しか所属できないようにしたいため、新規ユーザー登録の際にteamが定員に達しているかどうかを確認する処理を追加した。