### PR TITLE
貸し借りの状況をHOMEに表示する

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -39,6 +39,10 @@ RSpec/NestedGroups:
   Exclude:
     - spec/**/*
 
+RSpec/MultipleMemoizedHelpers:
+  Exclude:
+    - spec/**/*
+
 AllCops:
   Exclude:
     - "**/templates/**/*"

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -43,6 +43,10 @@ RSpec/MultipleMemoizedHelpers:
   Exclude:
     - spec/**/*
 
+RSpec/LetSetup:
+  Exclude:
+    - spec/models/team_spec.rb
+
 AllCops:
   Exclude:
     - "**/templates/**/*"

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -8,7 +8,8 @@ class Api::TeamsController < ApplicationController
     render json: {
       refund_amount: team.refund_amount,
       largest_payment_user: team.largest_payment_user,
-      smallest_payment_user: team.smallest_payment_user
+      smallest_payment_user: team.smallest_payment_user,
+      is_team_capacity_reached: team.capacity_reached?
     }
   end
 end

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 class Api::TeamsController < ApplicationController
   before_action :authenticate_api_user!
 

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -1,0 +1,12 @@
+class Api::TeamsController < ApplicationController
+  before_action :authenticate_api_user!
+
+  def show
+    team = Team.find(current_api_user.team_id)
+    render json: {
+      refund_amount: team.refund_amount,
+      largest_payment_user: team.largest_payment_user,
+      smallest_payment_user: team.smallest_payment_user
+    }
+  end
+end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -24,19 +24,15 @@ class Team < ApplicationRecord
   end
 
   def user_id_and_total_amount
-    users.map { |user| [user.id, user.payments.sum(:amount)]}.to_h
+    users.map { |user| [user.id, user.payments.sum(:amount)] }.to_h
   end
 
   def largest_payment_user
-    if user_id_and_total_amount.values.max != user_id_and_total_amount.values.min
-      User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.max))
-    end
+    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.max)) if user_id_and_total_amount.values.max != user_id_and_total_amount.values.min
   end
 
   def smallest_payment_user
-    if user_id_and_total_amount.values.max != user_id_and_total_amount.values.min
-      User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.min))
-    end
+    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.min)) if user_id_and_total_amount.values.max != user_id_and_total_amount.values.min
   end
 
   def capacity_reached?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -20,11 +20,11 @@ class Team < ApplicationRecord
   end
 
   def largest_payment_user
-    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.max)) unless refund_amount == 0
+    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.max)) unless refund_amount.zero?
   end
 
   def smallest_payment_user
-    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.min)) unless refund_amount == 0
+    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.min)) unless refund_amount.zero?
   end
 
   def capacity_reached?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -16,11 +16,7 @@ class Team < ApplicationRecord
   end
 
   def refund_amount
-    if user_id_and_total_amount.values.max == user_id_and_total_amount.values.min
-      0
-    else
-      largest_payment_user.payments.sum(:amount) - payment_per_person
-    end
+    (users.first.payments.sum(:amount) - payment_per_person).abs
   end
 
   def user_id_and_total_amount

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -16,17 +16,27 @@ class Team < ApplicationRecord
   end
 
   def refund_amount
-    self.largest_payment_user.payments.sum(:amount) - self.payment_per_person
+    if user_id_and_total_amount.values.max == user_id_and_total_amount.values.min
+      0
+    else
+      self.largest_payment_user.payments.sum(:amount) - self.payment_per_person
+    end
+  end
+
+  def user_id_and_total_amount
+    users.map { |user| [user.id, user.payments.sum(:amount)]}.to_h
   end
 
   def largest_payment_user
-    user_and_total_amount = users.map { |user| [user.id, user.payments.sum(:amount)]}.to_h
-    User.find(user_and_total_amount.key(user_and_total_amount.values.max))
+    if user_id_and_total_amount.values.max != user_id_and_total_amount.values.min
+      User.find(self.user_id_and_total_amount.key(user_id_and_total_amount.values.max))
+    end
   end
 
   def smallest_payment_user
-    user_and_total_amount = users.map { |user| [user.id, user.payments.sum(:amount)]}.to_h
-    User.find(user_and_total_amount.key(user_and_total_amount.values.min))
+    if user_id_and_total_amount.values.max != user_id_and_total_amount.values.min
+      User.find(self.user_id_and_total_amount.key(user_id_and_total_amount.values.min))
+    end
   end
 
   def capacity_reached?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -24,11 +24,11 @@ class Team < ApplicationRecord
   end
 
   def largest_payment_user
-    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.max)) if user_id_and_total_amount.values.max != user_id_and_total_amount.values.min
+    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.max)) unless refund_amount == 0
   end
 
   def smallest_payment_user
-    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.min)) if user_id_and_total_amount.values.max != user_id_and_total_amount.values.min
+    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.min)) unless refund_amount == 0
   end
 
   def capacity_reached?

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -7,6 +7,28 @@ class Team < ApplicationRecord
   # 現在は1teamにつき2人まで登録できるようにする
   MAX_TEAM_MENBER_NUMBER = 2
 
+  def total_amount
+    self.payments.sum(:amount)
+  end
+
+  def payment_per_person
+    self.total_amount / MAX_TEAM_MENBER_NUMBER
+  end
+
+  def refund_amount
+    self.largest_payment_user.payments.sum(:amount) - self.payment_per_person
+  end
+
+  def largest_payment_user
+    user_and_total_amount = users.map { |user| [user.id, user.payments.sum(:amount)]}.to_h
+    User.find(user_and_total_amount.key(user_and_total_amount.values.max))
+  end
+
+  def smallest_payment_user
+    user_and_total_amount = users.map { |user| [user.id, user.payments.sum(:amount)]}.to_h
+    User.find(user_and_total_amount.key(user_and_total_amount.values.min))
+  end
+
   def capacity_reached?
     users.length == MAX_TEAM_MENBER_NUMBER
   end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -8,18 +8,18 @@ class Team < ApplicationRecord
   MAX_TEAM_MENBER_NUMBER = 2
 
   def total_amount
-    self.payments.sum(:amount)
+    payments.sum(:amount)
   end
 
   def payment_per_person
-    self.total_amount / MAX_TEAM_MENBER_NUMBER
+    total_amount / MAX_TEAM_MENBER_NUMBER
   end
 
   def refund_amount
     if user_id_and_total_amount.values.max == user_id_and_total_amount.values.min
       0
     else
-      self.largest_payment_user.payments.sum(:amount) - self.payment_per_person
+      largest_payment_user.payments.sum(:amount) - payment_per_person
     end
   end
 
@@ -29,13 +29,13 @@ class Team < ApplicationRecord
 
   def largest_payment_user
     if user_id_and_total_amount.values.max != user_id_and_total_amount.values.min
-      User.find(self.user_id_and_total_amount.key(user_id_and_total_amount.values.max))
+      User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.max))
     end
   end
 
   def smallest_payment_user
     if user_id_and_total_amount.values.max != user_id_and_total_amount.values.min
-      User.find(self.user_id_and_total_amount.key(user_id_and_total_amount.values.min))
+      User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.min))
     end
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -11,12 +11,12 @@ class Team < ApplicationRecord
     payments.sum(:amount)
   end
 
-  def payment_per_person
+  def split_bill_amount
     total_amount / MAX_TEAM_MENBER_NUMBER
   end
 
   def refund_amount
-    (users.first.payments.sum(:amount) - payment_per_person).abs
+    (users.first.payments.sum(:amount) - split_bill_amount).abs
   end
 
   def user_id_and_total_amount

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -19,10 +19,6 @@ class Team < ApplicationRecord
     (users.first.payments.sum(:amount) - split_bill_amount).abs
   end
 
-  def user_id_and_total_amount
-    users.map { |user| [user.id, user.payments.sum(:amount)] }.to_h
-  end
-
   def largest_payment_user
     User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.max)) unless refund_amount == 0
   end
@@ -37,5 +33,11 @@ class Team < ApplicationRecord
 
   def self.invitation_token_exists?(invitation_token)
     Team.exists?(invitation_token: invitation_token)
+  end
+
+  private
+
+  def user_id_and_total_amount
+    users.map { |user| [user.id, user.payments.sum(:amount)] }.to_h
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -9,6 +9,7 @@ Rails.application.routes.draw do
     end
 
     resources :payments
+    resources :teams, only: %i[show]
   end
 
   get '*path', to: "application#fallback_index_html", constraints: ->(request) do

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -17,6 +17,7 @@ import { getCurrentUser } from 'lib/api/auth'
 import { theme } from 'theme'
 
 import type { Payment } from 'types/payment'
+import type { TeamStatus } from 'types/teamStatus'
 import type { User } from 'types/user'
 
 const App: VFC = () => {
@@ -25,6 +26,11 @@ const App: VFC = () => {
   const [currentUser, setCurrentUser] = useState<User | null>(null)
   const [inputNumber, setInputNumber] = useState<string>('0')
   const [paymentList, setPaymentList] = useState<Payment[] | null>(null)
+  const [teamStatus, setTeamStatus] = useState<TeamStatus>({
+    refundAmount: 0,
+    largestPaymentUser: null,
+    smallestPaymentUser: null,
+  })
   const [isPaymentsLoaded, setIsPaymentsLoaded] = useState<boolean>(false)
 
   // サインイン状態をチェック
@@ -69,6 +75,8 @@ const App: VFC = () => {
                   setPaymentList,
                   isPaymentsLoaded,
                   setIsPaymentsLoaded,
+                  teamStatus,
+                  setTeamStatus,
                 }}
               >
                 <PrivateRoute>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -30,6 +30,7 @@ const App: VFC = () => {
     refundAmount: 0,
     largestPaymentUser: null,
     smallestPaymentUser: null,
+    isTeamCapacityReached: false,
   })
   const [isPaymentsLoaded, setIsPaymentsLoaded] = useState<boolean>(false)
 

--- a/frontend/src/components/atoms/alert/NoRefundAlert.tsx
+++ b/frontend/src/components/atoms/alert/NoRefundAlert.tsx
@@ -1,9 +1,0 @@
-import { VFC } from 'react'
-
-import { Alert } from '@chakra-ui/react'
-
-export const NoRefundAlert: VFC = () => (
-  <Alert status="success" variant="subtle" justifyContent="center" fontSize="sm" p={1}>
-    現在貸し借りはありません
-  </Alert>
-)

--- a/frontend/src/components/atoms/alert/NoRefundAlert.tsx
+++ b/frontend/src/components/atoms/alert/NoRefundAlert.tsx
@@ -2,7 +2,7 @@ import { VFC } from 'react'
 
 import { Alert } from '@chakra-ui/react'
 
-export const BasicAlert: VFC = () => (
+export const NoRefundAlert: VFC = () => (
   <Alert status="success" variant="subtle" justifyContent="center" fontSize="sm" p={1}>
     現在貸し借りはありません
   </Alert>

--- a/frontend/src/components/atoms/alert/debtAlert.tsx
+++ b/frontend/src/components/atoms/alert/debtAlert.tsx
@@ -1,0 +1,9 @@
+import { VFC } from 'react'
+
+import { Alert } from '@chakra-ui/react'
+
+export const DebtAlert: VFC = () => (
+  <Alert status="error" variant="subtle" justifyContent="center" fontSize="sm" p={1}>
+    現在あなたは借金中です
+  </Alert>
+)

--- a/frontend/src/components/organisms/CurrentStatusArea.tsx
+++ b/frontend/src/components/organisms/CurrentStatusArea.tsx
@@ -1,10 +1,23 @@
-import { memo, VFC } from 'react'
+import { memo, useContext, VFC } from 'react'
 
 import { Box, Center } from '@chakra-ui/react'
 
-export const CurrentStatusArea: VFC = memo(() => (
-  <Box p={16}>
-    <Center>taroに返す金額</Center>
-    <Center>32600</Center>
-  </Box>
-))
+import { AuthContext } from 'context/AuthContext'
+import { PaymentContext } from 'context/PaymentContext'
+
+export const CurrentStatusArea: VFC = memo(() => {
+  const { teamStatus } = useContext(PaymentContext)
+  const { currentUser } = useContext(AuthContext)
+
+  return (
+    <Box p={16}>
+      {currentUser?.id === teamStatus.largestPaymentUser?.id && (
+        <Center>{teamStatus.smallestPaymentUser?.name}に返してもらう金額</Center>
+      )}
+      {currentUser?.id !== teamStatus.largestPaymentUser?.id && (
+        <Center>{teamStatus.largestPaymentUser?.name}に返す金額</Center>
+      )}
+      <Center>{teamStatus.refundAmount}</Center>
+    </Box>
+  )
+})

--- a/frontend/src/components/organisms/CurrentStatusArea.tsx
+++ b/frontend/src/components/organisms/CurrentStatusArea.tsx
@@ -11,13 +11,14 @@ export const CurrentStatusArea: VFC = memo(() => {
 
   return (
     <Box p={16}>
-      {currentUser?.id === teamStatus.largestPaymentUser?.id && (
+      {teamStatus.refundAmount === 0 && '現在貸し借りはありません'}
+      {teamStatus.refundAmount !== 0 && currentUser?.id === teamStatus.largestPaymentUser?.id && (
         <Center>{teamStatus.smallestPaymentUser?.name}に返してもらう金額</Center>
       )}
-      {currentUser?.id !== teamStatus.largestPaymentUser?.id && (
+      {teamStatus.refundAmount !== 0 && currentUser?.id !== teamStatus.largestPaymentUser?.id && (
         <Center>{teamStatus.largestPaymentUser?.name}に返す金額</Center>
       )}
-      <Center>{teamStatus.refundAmount}</Center>
+      <Center>{teamStatus.refundAmount !== 0 && teamStatus.refundAmount}</Center>
     </Box>
   )
 })

--- a/frontend/src/components/organisms/UnavailableStatusArea.tsx
+++ b/frontend/src/components/organisms/UnavailableStatusArea.tsx
@@ -1,0 +1,12 @@
+import { memo, VFC } from 'react'
+
+import { Box, Center } from '@chakra-ui/react'
+
+export const UnavailableStatusArea: VFC = memo(() => (
+  <Box p={16} _before={{ content: `"相手が登録を完了すると表示されます"`, position: 'absolute' }}>
+    <Box opacity={0.2}>
+      <Center>タロウに返す金額</Center>
+      <Center>2000</Center>
+    </Box>
+  </Box>
+))

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -3,7 +3,8 @@ import { Link } from 'react-router-dom'
 
 import { Box, Center, Flex, Spacer, useDisclosure } from '@chakra-ui/react'
 
-import { BasicAlert } from 'components/atoms/alert/BasicAlert'
+import { DebtAlert } from 'components/atoms/alert/debtAlert'
+import { NoRefundAlert } from 'components/atoms/alert/NoRefundAlert'
 import { CircleAddButton } from 'components/atoms/button/CircleAddButton'
 import { DangerButton } from 'components/atoms/button/DangerButton'
 import { BasicModal } from 'components/organisms/BasicModal'
@@ -16,7 +17,7 @@ import { getTeamStatus } from 'lib/api/team'
 import { useToast } from 'lib/toast'
 
 export const Home: VFC = memo(() => {
-  const { paymentList, setPaymentList, isPaymentsLoaded, setIsPaymentsLoaded, setTeamStatus } =
+  const { paymentList, setPaymentList, isPaymentsLoaded, setIsPaymentsLoaded, teamStatus, setTeamStatus } =
     useContext(PaymentContext)
   const { currentUser } = useContext(AuthContext)
   const { errorToast } = useToast()
@@ -63,7 +64,9 @@ export const Home: VFC = memo(() => {
   return (
     <>
       <BasicModal isOpen={isOpenSettleModal} onClose={onCloseSettleModal} size="xl" />
-      <BasicAlert />
+      {teamStatus.refundAmount === 0 && <NoRefundAlert />}
+      {currentUser?.id === teamStatus.smallestPaymentUser?.id && <DebtAlert />}
+
       <CurrentStatusArea />
       <Flex bgColor="gray.50" p={2} align="center">
         支払い履歴

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -9,12 +9,16 @@ import { DangerButton } from 'components/atoms/button/DangerButton'
 import { BasicModal } from 'components/organisms/BasicModal'
 import { CurrentStatusArea } from 'components/organisms/CurrentStatusArea'
 import { PaymentList } from 'components/organisms/PaymentList'
+import { AuthContext } from 'context/AuthContext'
 import { PaymentContext } from 'context/PaymentContext'
 import { getPayments } from 'lib/api/payment'
+import { getTeamStatus } from 'lib/api/team'
 import { useToast } from 'lib/toast'
 
 export const Home: VFC = memo(() => {
-  const { paymentList, setPaymentList, isPaymentsLoaded, setIsPaymentsLoaded } = useContext(PaymentContext)
+  const { paymentList, setPaymentList, isPaymentsLoaded, setIsPaymentsLoaded, setTeamStatus } =
+    useContext(PaymentContext)
+  const { currentUser } = useContext(AuthContext)
   const { errorToast } = useToast()
   const { isOpen: isOpenSettleModal, onOpen: onOpenSettleModal, onClose: onCloseSettleModal } = useDisclosure()
 
@@ -32,8 +36,25 @@ export const Home: VFC = memo(() => {
     setIsPaymentsLoaded(true)
   }
 
+  const handleGetTeamStatus = async () => {
+    try {
+      const res = await getTeamStatus(currentUser!.teamId)
+      if (res?.status === 200) {
+        setTeamStatus(res?.data)
+      } else {
+        errorToast('取得に失敗しました')
+      }
+    } catch {
+      errorToast('取得に失敗しました')
+    }
+    setIsPaymentsLoaded(true)
+  }
+
   useEffect(() => {
     handleGetPayments().catch((err) => {
+      console.log(err)
+    })
+    handleGetTeamStatus().catch((err) => {
       console.log(err)
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -10,6 +10,7 @@ import { DangerButton } from 'components/atoms/button/DangerButton'
 import { BasicModal } from 'components/organisms/BasicModal'
 import { CurrentStatusArea } from 'components/organisms/CurrentStatusArea'
 import { PaymentList } from 'components/organisms/PaymentList'
+import { UnavailableStatusArea } from 'components/organisms/UnavailableStatusArea'
 import { AuthContext } from 'context/AuthContext'
 import { PaymentContext } from 'context/PaymentContext'
 import { getPayments } from 'lib/api/payment'
@@ -64,10 +65,8 @@ export const Home: VFC = memo(() => {
   return (
     <>
       <BasicModal isOpen={isOpenSettleModal} onClose={onCloseSettleModal} size="xl" />
-      {teamStatus.refundAmount === 0 && <NoRefundAlert />}
       {currentUser?.id === teamStatus.smallestPaymentUser?.id && <DebtAlert />}
-
-      <CurrentStatusArea />
+      {teamStatus.isTeamCapacityReached ? <CurrentStatusArea /> : <UnavailableStatusArea />}
       <Flex bgColor="gray.50" p={2} align="center">
         支払い履歴
         <Spacer />

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -4,7 +4,6 @@ import { Link } from 'react-router-dom'
 import { Box, Center, Flex, Spacer, useDisclosure } from '@chakra-ui/react'
 
 import { DebtAlert } from 'components/atoms/alert/debtAlert'
-import { NoRefundAlert } from 'components/atoms/alert/NoRefundAlert'
 import { CircleAddButton } from 'components/atoms/button/CircleAddButton'
 import { DangerButton } from 'components/atoms/button/DangerButton'
 import { BasicModal } from 'components/organisms/BasicModal'

--- a/frontend/src/context/PaymentContext.ts
+++ b/frontend/src/context/PaymentContext.ts
@@ -1,6 +1,7 @@
 import { createContext } from 'react'
 
 import type { Payment } from 'types/payment'
+import type { TeamStatus } from 'types/teamStatus'
 
 export type PaymentContextType = {
   inputNumber: string
@@ -9,6 +10,8 @@ export type PaymentContextType = {
   setPaymentList: React.Dispatch<React.SetStateAction<Payment[] | null>>
   isPaymentsLoaded: boolean
   setIsPaymentsLoaded: React.Dispatch<React.SetStateAction<boolean>>
+  teamStatus: TeamStatus
+  setTeamStatus: React.Dispatch<React.SetStateAction<TeamStatus>>
 }
 
 export const PaymentContext = createContext<PaymentContextType>({
@@ -22,6 +25,14 @@ export const PaymentContext = createContext<PaymentContextType>({
   },
   isPaymentsLoaded: false,
   setIsPaymentsLoaded: () => {
+    throw new Error('PaymentContext not avaliable')
+  },
+  teamStatus: {
+    refundAmount: 0,
+    largestPaymentUser: null,
+    smallestPaymentUser: null,
+  },
+  setTeamStatus: () => {
     throw new Error('PaymentContext not avaliable')
   },
 })

--- a/frontend/src/context/PaymentContext.ts
+++ b/frontend/src/context/PaymentContext.ts
@@ -31,6 +31,7 @@ export const PaymentContext = createContext<PaymentContextType>({
     refundAmount: 0,
     largestPaymentUser: null,
     smallestPaymentUser: null,
+    isTeamCapacityReached: false,
   },
   setTeamStatus: () => {
     throw new Error('PaymentContext not avaliable')

--- a/frontend/src/lib/api/team.ts
+++ b/frontend/src/lib/api/team.ts
@@ -2,9 +2,9 @@ import { AxiosPromise } from 'axios'
 import Cookies from 'js-cookie'
 
 import client from 'lib/api/client'
-import { TeamStatusResponse } from 'types/teamStatusResponse'
+import { TeamStatus } from 'types/teamStatus'
 
-export const getTeamStatus = (id: number): AxiosPromise<TeamStatusResponse[] | null> =>
+export const getTeamStatus = (id: number): AxiosPromise<TeamStatus[] | null> =>
   client.get(`/teams/${id}`, {
     headers: {
       'access-token': Cookies.get('_access_token') || '',

--- a/frontend/src/lib/api/team.ts
+++ b/frontend/src/lib/api/team.ts
@@ -1,0 +1,14 @@
+import { AxiosPromise } from 'axios'
+import Cookies from 'js-cookie'
+
+import client from 'lib/api/client'
+import { TeamStatusResponse } from 'types/teamStatusResponse'
+
+export const getTeamStatus = (id: number): AxiosPromise<TeamStatusResponse[] | null> =>
+  client.get(`/teams/${id}`, {
+    headers: {
+      'access-token': Cookies.get('_access_token') || '',
+      client: Cookies.get('_client') || '',
+      uid: Cookies.get('_uid') || '',
+    },
+  })

--- a/frontend/src/lib/api/team.ts
+++ b/frontend/src/lib/api/team.ts
@@ -4,7 +4,7 @@ import Cookies from 'js-cookie'
 import client from 'lib/api/client'
 import { TeamStatus } from 'types/teamStatus'
 
-export const getTeamStatus = (id: number): AxiosPromise<TeamStatus[] | null> =>
+export const getTeamStatus = (id: number): AxiosPromise<TeamStatus> =>
   client.get(`/teams/${id}`, {
     headers: {
       'access-token': Cookies.get('_access_token') || '',

--- a/frontend/src/types/teamStatus.ts
+++ b/frontend/src/types/teamStatus.ts
@@ -2,6 +2,6 @@ import type { User } from './user'
 
 export type TeamStatus = {
   refundAmount: number
-  largestPaymentUser: User
-  smallestPaymentUser: User
+  largestPaymentUser: User | null
+  smallestPaymentUser: User | null
 }

--- a/frontend/src/types/teamStatus.ts
+++ b/frontend/src/types/teamStatus.ts
@@ -4,4 +4,5 @@ export type TeamStatus = {
   refundAmount: number
   largestPaymentUser: User | null
   smallestPaymentUser: User | null
+  isTeamCapacityReached: boolean
 }

--- a/frontend/src/types/teamStatus.ts
+++ b/frontend/src/types/teamStatus.ts
@@ -1,6 +1,6 @@
 import type { User } from './user'
 
-export type TeamStatusResponse = {
+export type TeamStatus = {
   refundAmount: number
   largestPaymentUser: User
   smallestPaymentUser: User

--- a/frontend/src/types/teamStatusResponse.ts
+++ b/frontend/src/types/teamStatusResponse.ts
@@ -1,0 +1,7 @@
+import type { User } from './user'
+
+export type TeamStatusResponse = {
+  refundAmount: number
+  largestPaymentUser: User
+  smallestPaymentUser: User
+}

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -20,17 +20,17 @@ RSpec.describe Team, type: :model do
 
   context '支払い金額' do
     context '片方が多く支払っている場合' do
-      let!(:user_1) { create(:user, :with_team) }
-      let!(:user_2) { create(:user, team_id: user_1.team_id) }
-      let!(:team) { user_1.team }
-      let!(:payment_1) { user_1.payments.create(amount: 800, team_id: team.id) }
-      let!(:payment_2) { user_1.payments.create(amount: 200, team_id: team.id) }
-      let!(:payment_3) { user_2.payments.create(amount: 100, team_id: team.id) }
-      let!(:payment_4) { user_2.payments.create(amount: 300, team_id: team.id) }
+      let!(:user1) { create(:user, :with_team) }
+      let!(:user2) { create(:user, team_id: user1.team_id) }
+      let!(:team) { user1.team }
+      let!(:payment1) { user1.payments.create(amount: 800, team_id: team.id) }
+      let!(:payment2) { user1.payments.create(amount: 200, team_id: team.id) }
+      let!(:payment3) { user2.payments.create(amount: 100, team_id: team.id) }
+      let!(:payment4) { user2.payments.create(amount: 300, team_id: team.id) }
 
       example '各ユーザーの合計金額' do
-        expect(user_1.payments.sum(:amount)).to eq 1000
-        expect(user_2.payments.sum(:amount)).to eq 400
+        expect(user1.payments.sum(:amount)).to eq 1000
+        expect(user2.payments.sum(:amount)).to eq 400
       end
 
       example 'teamの合計金額' do
@@ -46,22 +46,22 @@ RSpec.describe Team, type: :model do
       end
 
       example '一人当たり支払うべき金額より多く支払っているユーザー' do
-        expect(team.largest_payment_user).to eq user_1
+        expect(team.largest_payment_user).to eq user1
       end
 
       example '一人当たり支払うべき金額より支払いが少ないユーザー' do
-        expect(team.smallest_payment_user).to eq user_2
+        expect(team.smallest_payment_user).to eq user2
       end
     end
 
     context '2人の支払い金額が同じ場合' do
-      let!(:user_1) { create(:user, :with_team) }
-      let!(:user_2) { create(:user, team_id: user_1.team_id) }
-      let!(:team) { user_1.team }
-      let!(:payment_1) { user_1.payments.create(amount: 800, team_id: team.id) }
-      let!(:payment_2) { user_1.payments.create(amount: 200, team_id: team.id) }
-      let!(:payment_3) { user_2.payments.create(amount: 500, team_id: team.id) }
-      let!(:payment_4) { user_2.payments.create(amount: 500, team_id: team.id) }
+      let!(:user1) { create(:user, :with_team) }
+      let!(:user2) { create(:user, team_id: user1.team_id) }
+      let!(:team) { user1.team }
+      let!(:payment1) { user1.payments.create(amount: 800, team_id: team.id) }
+      let!(:payment2) { user1.payments.create(amount: 200, team_id: team.id) }
+      let!(:payment3) { user2.payments.create(amount: 500, team_id: team.id) }
+      let!(:payment4) { user2.payments.create(amount: 500, team_id: team.id) }
 
       example '1人あたり支払うべき金額' do
         expect(team.payment_per_person).to eq 1000
@@ -81,13 +81,13 @@ RSpec.describe Team, type: :model do
     end
 
     context '支払い金額が0の場合' do
-      let!(:user_1) { create(:user, :with_team) }
-      let!(:user_2) { create(:user, team_id: user_1.team_id) }
-      let!(:team) { user_1.team }
+      let!(:user1) { create(:user, :with_team) }
+      let!(:user2) { create(:user, team_id: user1.team_id) }
+      let!(:team) { user1.team }
 
       example '各ユーザーの合計金額' do
-        expect(user_1.payments.sum(:amount)).to eq 0
-        expect(user_2.payments.sum(:amount)).to eq 0
+        expect(user1.payments.sum(:amount)).to eq 0
+        expect(user2.payments.sum(:amount)).to eq 0
       end
 
       example 'teamの合計金額' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -3,16 +3,53 @@
 require 'rails_helper'
 
 RSpec.describe Team, type: :model do
-  example '1つのteamに含まれるユーザーが2人の時満員となる' do
-    host_user = create(:user, :with_team)
-    guest_user = build(:user)
-    guest_user.team_id = host_user.team_id
-    guest_user.save
-    expect(host_user.team.capacity_reached?).to be true
+  context '人数制限' do
+    example '1つのteamに含まれるユーザーが2人の時満員となる' do
+      host_user = create(:user, :with_team)
+      guest_user = build(:user)
+      guest_user.team_id = host_user.team_id
+      guest_user.save
+      expect(host_user.team.capacity_reached?).to be true
+    end
+
+    example '1つのteamに含まれるユーザーが1人の時は満員ではない' do
+      host_user = create(:user, :with_team)
+      expect(host_user.team.capacity_reached?).to be false
+    end
   end
 
-  example '1つのteamに含まれるユーザーが1人の時は満員ではない' do
-    host_user = create(:user, :with_team)
-    expect(host_user.team.capacity_reached?).to be false
+  context '支払い金額' do
+    let!(:user_1) { create(:user, :with_team) }
+    let!(:user_2) { create(:user, team_id: user_1.team_id) }
+    let!(:team) { user_1.team }
+    let!(:payment_1) { user_1.payments.create(amount: 800, team_id: team.id) }
+    let!(:payment_2) { user_1.payments.create(amount: 200, team_id: team.id) }
+    let!(:payment_3) { user_2.payments.create(amount: 100, team_id: team.id) }
+    let!(:payment_4) { user_2.payments.create(amount: 300, team_id: team.id) }
+
+    example '各ユーザーの合計金額' do
+      expect(user_1.payments.sum(:amount)).to eq 1000
+      expect(user_2.payments.sum(:amount)).to eq 400
+    end
+
+    example 'teamの合計金額' do
+      expect(team.total_amount).to eq 1400
+    end
+
+    example '1人あたり支払うべき金額' do
+      expect(team.payment_per_person).to eq 700
+    end
+
+    example '返金額' do
+      expect(team.refund_amount).to eq 300
+    end
+
+    example '一人当たり支払うべき金額より多く支払っているユーザー' do
+      expect(team.largest_payment_user).to eq user_1
+    end
+
+    example '一人当たり支払うべき金額より支払いが少ないユーザー' do
+      expect(team.smallest_payment_user).to eq user_2
+    end
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -19,37 +19,96 @@ RSpec.describe Team, type: :model do
   end
 
   context '支払い金額' do
-    let!(:user_1) { create(:user, :with_team) }
-    let!(:user_2) { create(:user, team_id: user_1.team_id) }
-    let!(:team) { user_1.team }
-    let!(:payment_1) { user_1.payments.create(amount: 800, team_id: team.id) }
-    let!(:payment_2) { user_1.payments.create(amount: 200, team_id: team.id) }
-    let!(:payment_3) { user_2.payments.create(amount: 100, team_id: team.id) }
-    let!(:payment_4) { user_2.payments.create(amount: 300, team_id: team.id) }
+    context '片方が多く支払っている場合' do
+      let!(:user_1) { create(:user, :with_team) }
+      let!(:user_2) { create(:user, team_id: user_1.team_id) }
+      let!(:team) { user_1.team }
+      let!(:payment_1) { user_1.payments.create(amount: 800, team_id: team.id) }
+      let!(:payment_2) { user_1.payments.create(amount: 200, team_id: team.id) }
+      let!(:payment_3) { user_2.payments.create(amount: 100, team_id: team.id) }
+      let!(:payment_4) { user_2.payments.create(amount: 300, team_id: team.id) }
 
-    example '各ユーザーの合計金額' do
-      expect(user_1.payments.sum(:amount)).to eq 1000
-      expect(user_2.payments.sum(:amount)).to eq 400
+      example '各ユーザーの合計金額' do
+        expect(user_1.payments.sum(:amount)).to eq 1000
+        expect(user_2.payments.sum(:amount)).to eq 400
+      end
+
+      example 'teamの合計金額' do
+        expect(team.total_amount).to eq 1400
+      end
+
+      example '1人あたり支払うべき金額' do
+        expect(team.payment_per_person).to eq 700
+      end
+
+      example '返金額' do
+        expect(team.refund_amount).to eq 300
+      end
+
+      example '一人当たり支払うべき金額より多く支払っているユーザー' do
+        expect(team.largest_payment_user).to eq user_1
+      end
+
+      example '一人当たり支払うべき金額より支払いが少ないユーザー' do
+        expect(team.smallest_payment_user).to eq user_2
+      end
     end
 
-    example 'teamの合計金額' do
-      expect(team.total_amount).to eq 1400
+    context '2人の支払い金額が同じ場合' do
+      let!(:user_1) { create(:user, :with_team) }
+      let!(:user_2) { create(:user, team_id: user_1.team_id) }
+      let!(:team) { user_1.team }
+      let!(:payment_1) { user_1.payments.create(amount: 800, team_id: team.id) }
+      let!(:payment_2) { user_1.payments.create(amount: 200, team_id: team.id) }
+      let!(:payment_3) { user_2.payments.create(amount: 500, team_id: team.id) }
+      let!(:payment_4) { user_2.payments.create(amount: 500, team_id: team.id) }
+
+      example '1人あたり支払うべき金額' do
+        expect(team.payment_per_person).to eq 1000
+      end
+
+      example '返金額' do
+        expect(team.refund_amount).to eq 0
+      end
+
+      example '一人当たり支払うべき金額より多く支払っているユーザー' do
+        expect(team.largest_payment_user).to eq nil
+      end
+
+      example '一人当たり支払うべき金額より支払いが少ないユーザー' do
+        expect(team.smallest_payment_user).to eq nil
+      end
     end
 
-    example '1人あたり支払うべき金額' do
-      expect(team.payment_per_person).to eq 700
-    end
+    context '支払い金額が0の場合' do
+      let!(:user_1) { create(:user, :with_team) }
+      let!(:user_2) { create(:user, team_id: user_1.team_id) }
+      let!(:team) { user_1.team }
 
-    example '返金額' do
-      expect(team.refund_amount).to eq 300
-    end
+      example '各ユーザーの合計金額' do
+        expect(user_1.payments.sum(:amount)).to eq 0
+        expect(user_2.payments.sum(:amount)).to eq 0
+      end
 
-    example '一人当たり支払うべき金額より多く支払っているユーザー' do
-      expect(team.largest_payment_user).to eq user_1
-    end
+      example 'teamの合計金額' do
+        expect(team.total_amount).to eq 0
+      end
 
-    example '一人当たり支払うべき金額より支払いが少ないユーザー' do
-      expect(team.smallest_payment_user).to eq user_2
+      example '1人あたり支払うべき金額' do
+        expect(team.payment_per_person).to eq 0
+      end
+
+      example '返金額' do
+        expect(team.refund_amount).to eq 0
+      end
+
+      example '一人当たり支払うべき金額より多く支払っているユーザー' do
+        expect(team.largest_payment_user).to eq nil
+      end
+
+      example '一人当たり支払うべき金額より支払いが少ないユーザー' do
+        expect(team.smallest_payment_user).to eq nil
+      end
     end
   end
 end

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -18,13 +18,16 @@ RSpec.describe Team, type: :model do
 
   context '支払い金額' do
     context '片方が多く支払っている場合' do
-      let!(:user1) { create(:user, :with_team) }
-      let!(:user2) { create(:user, team_id: user1.team_id) }
-      let!(:team) { user1.team }
-      let!(:payment1) { user1.payments.create(amount: 800, team_id: team.id) }
-      let!(:payment2) { user1.payments.create(amount: 200, team_id: team.id) }
-      let!(:payment3) { user2.payments.create(amount: 100, team_id: team.id) }
-      let!(:payment4) { user2.payments.create(amount: 300, team_id: team.id) }
+      let(:user1) { create(:user, :with_team) }
+      let(:user2) { create(:user, team_id: user1.team_id) }
+      let(:team) { user1.team }
+
+      before do
+        user1.payments.create(amount: 800, team_id: team.id)
+        user1.payments.create(amount: 200, team_id: team.id)
+        user2.payments.create(amount: 100, team_id: team.id)
+        user2.payments.create(amount: 300, team_id: team.id)
+      end
 
       example '各ユーザーの合計金額' do
         expect(user1.payments.sum(:amount)).to eq 1000
@@ -53,13 +56,16 @@ RSpec.describe Team, type: :model do
     end
 
     context '2人の支払い金額が同じ場合' do
-      let!(:user1) { create(:user, :with_team) }
-      let!(:user2) { create(:user, team_id: user1.team_id) }
-      let!(:team) { user1.team }
-      let!(:payment1) { user1.payments.create(amount: 800, team_id: team.id) }
-      let!(:payment2) { user1.payments.create(amount: 200, team_id: team.id) }
-      let!(:payment3) { user2.payments.create(amount: 500, team_id: team.id) }
-      let!(:payment4) { user2.payments.create(amount: 500, team_id: team.id) }
+      let(:user1) { create(:user, :with_team) }
+      let(:user2) { create(:user, team_id: user1.team_id) }
+      let(:team) { user1.team }
+
+      before do
+        user1.payments.create(amount: 800, team_id: team.id)
+        user1.payments.create(amount: 200, team_id: team.id)
+        user2.payments.create(amount: 500, team_id: team.id)
+        user2.payments.create(amount: 500, team_id: team.id)
+      end
 
       example '1人あたり支払うべき金額' do
         expect(team.split_bill_amount).to eq 1000
@@ -79,9 +85,9 @@ RSpec.describe Team, type: :model do
     end
 
     context '支払い金額が0の場合' do
-      let!(:user1) { create(:user, :with_team) }
-      let!(:user2) { create(:user, team_id: user1.team_id) }
-      let!(:team) { user1.team }
+      let(:user1) { create(:user, :with_team) }
+      let(:user2) { create(:user, team_id: user1.team_id) }
+      let(:team) { user1.team }
 
       example '各ユーザーの合計金額' do
         expect(user1.payments.sum(:amount)).to eq 0

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -38,7 +38,7 @@ RSpec.describe Team, type: :model do
       end
 
       example '1人あたり支払うべき金額' do
-        expect(team.payment_per_person).to eq 700
+        expect(team.split_bill_amount).to eq 700
       end
 
       example '返金額' do
@@ -64,7 +64,7 @@ RSpec.describe Team, type: :model do
       let!(:payment4) { user2.payments.create(amount: 500, team_id: team.id) }
 
       example '1人あたり支払うべき金額' do
-        expect(team.payment_per_person).to eq 1000
+        expect(team.split_bill_amount).to eq 1000
       end
 
       example '返金額' do
@@ -95,7 +95,7 @@ RSpec.describe Team, type: :model do
       end
 
       example '1人あたり支払うべき金額' do
-        expect(team.payment_per_person).to eq 0
+        expect(team.split_bill_amount).to eq 0
       end
 
       example '返金額' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -4,17 +4,15 @@ require 'rails_helper'
 
 RSpec.describe Team, type: :model do
   context '人数制限' do
-    example '1つのteamに含まれるユーザーが2人の時満員となる' do
-      host_user = create(:user, :with_team)
-      guest_user = build(:user)
-      guest_user.team_id = host_user.team_id
-      guest_user.save
-      expect(host_user.team.capacity_reached?).to be true
-    end
+    let(:host_user) { create(:user, :with_team) }
 
     example '1つのteamに含まれるユーザーが1人の時は満員ではない' do
-      host_user = create(:user, :with_team)
       expect(host_user.team.capacity_reached?).to be false
+    end
+
+    example '1つのteamに含まれるユーザーが2人の時満員となる' do
+      guest_user = create(:user, team_id: host_user.team_id)
+      expect(host_user.team.capacity_reached?).to be true
     end
   end
 

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Team, type: :model do
     end
 
     example '1つのteamに含まれるユーザーが2人の時満員となる' do
-      guest_user = create(:user, team_id: host_user.team_id)
+      create(:user, team_id: host_user.team_id)
       expect(host_user.team.capacity_reached?).to be true
     end
   end

--- a/spec/requests/api/teams_spec.rb
+++ b/spec/requests/api/teams_spec.rb
@@ -3,9 +3,9 @@
 require 'rails_helper'
 
 RSpec.describe 'Api::Teams', type: :request do
-  let!(:current_user) { create(:user, :with_team) }
-  let!(:other_user) { create(:user, team_id: current_user.team_id) }
-  let!(:team) { Team.find(current_user.team_id) }
+  let(:current_user) { create(:user, :with_team) }
+  let(:other_user) { create(:user, team_id: current_user.team_id) }
+  let(:team) { Team.find(current_user.team_id) }
 
   def auth_headers
     post new_api_user_session_path, params: { email: current_user.email, password: current_user.password }

--- a/spec/requests/api/teams_spec.rb
+++ b/spec/requests/api/teams_spec.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::Teams', type: :request do
+  let!(:current_user) { create(:user, :with_team) }
+  let!(:other_user) { create(:user, team_id: current_user.team_id) }
+  let!(:team) { Team.find(current_user.team_id) }
+
+  def auth_headers
+    post new_api_user_session_path, params: { email: current_user.email, password: current_user.password }
+    { 'uid' => response.header['uid'], 'client' => response.header['client'], 'access-token' => response.header['access-token'] }
+  end
+
+  def login
+    post api_user_session_path,
+         params: { email: current_user.email, password: current_user.password }.to_json,
+         headers: { 'CONTENT_TYPE' => 'application/json', 'ACCEPT' => 'application/json' }
+  end
+
+  describe 'GET /api/teams/:id' do
+    example 'チームの状況を取得することができる' do
+      5.times do |n|
+        current_user.payments.create(amount: 100 * (n + 1), team_id: current_user.team_id)
+      end # 1500
+      get api_team_path(current_user.team_id), headers: auth_headers
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to eq(
+        {
+          refund_amount: team.refund_amount,
+          largest_payment_user: team.largest_payment_user,
+          smallest_payment_user: team.smallest_payment_user,
+          is_team_capacity_reached: team.capacity_reached?,
+        }.to_json
+      )
+    end
+  end
+end

--- a/spec/requests/api/teams_spec.rb
+++ b/spec/requests/api/teams_spec.rb
@@ -22,7 +22,7 @@ RSpec.describe 'Api::Teams', type: :request do
     example 'チームの状況を取得することができる' do
       5.times do |n|
         current_user.payments.create(amount: 100 * (n + 1), team_id: current_user.team_id)
-      end # 1500
+      end
       get api_team_path(current_user.team_id), headers: auth_headers
       expect(response).to have_http_status(:ok)
       expect(response.body).to eq(
@@ -30,7 +30,7 @@ RSpec.describe 'Api::Teams', type: :request do
           refund_amount: team.refund_amount,
           largest_payment_user: team.largest_payment_user,
           smallest_payment_user: team.smallest_payment_user,
-          is_team_capacity_reached: team.capacity_reached?,
+          is_team_capacity_reached: team.capacity_reached?
         }.to_json
       )
     end


### PR DESCRIPTION
## issue
#18 

## できるようになること（ユーザ目線）
* 現在どちらにいくら貸している/借りている状況なのかを確認することができる

## やったこと
* 相手に返してもらう/返す金額を計算するメソッドを作成（Teamモデル）
* Teamの状況を取得するTeams APIの作成
* 返してもらう/返す金額をフロントに表示
* 割り勘額より支払額が少ないユーザーには「あなたは現在借金中です」のラベルを表示
* テストの作成
    * Teamモデルスペック
    * Teams APIリクエストスペック




