### PR TITLE
apiのコントローラはApi::ApplicationControllerを継承させる

### DIFF
--- a/app/controllers/api/application_controller.rb
+++ b/app/controllers/api/application_controller.rb
@@ -1,0 +1,6 @@
+# frozen_string_literal: true
+
+class Api::ApplicationController < ActionController::API
+  include Firebase::Auth::Authenticable
+  before_action :authenticate_user
+end

--- a/app/controllers/api/auth/registrations_controller.rb
+++ b/app/controllers/api/auth/registrations_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::Auth::RegistrationsController < ApplicationController
+class Api::Auth::RegistrationsController < Api::ApplicationController
   skip_before_action :authenticate_user
   before_action :check_invitation_token_and_team_capacity, only: :create
   after_action :attach_default_avatar, only: :create

--- a/app/controllers/api/auth/sessions_controller.rb
+++ b/app/controllers/api/auth/sessions_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::Auth::SessionsController < ApplicationController
+class Api::Auth::SessionsController < Api::ApplicationController
   skip_before_action :authenticate_user
 
   def index

--- a/app/controllers/api/payments_controller.rb
+++ b/app/controllers/api/payments_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::PaymentsController < ApplicationController
+class Api::PaymentsController < Api::ApplicationController
   before_action :set_payment, only: %i[destroy update]
 
   def index

--- a/app/controllers/api/teams/payments_controller.rb
+++ b/app/controllers/api/teams/payments_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::Teams::PaymentsController < ApplicationController
+class Api::Teams::PaymentsController < Api::ApplicationController
   before_action :authenticate_api_user!
 
   def update

--- a/app/controllers/api/teams_controller.rb
+++ b/app/controllers/api/teams_controller.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-class Api::TeamsController < ApplicationController
+class Api::TeamsController < Api::ApplicationController
   def show
     @team = Team.find(current_user.team_id)
     render :show

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,8 +2,6 @@
 
 class ApplicationController < ActionController::API
   include ActionController::MimeResponds
-  include Firebase::Auth::Authenticable
-  before_action :authenticate_user
 
   def fallback_index_html
     respond_to do |format|


### PR DESCRIPTION
## やったこと
* Firebase Authの`before_action :authenticate_user`を実行するコントローラーを`ApplicationController`から`Api::ApplicationController`とする
* apiのコントローラは`Api::ApplicationController`を継承することで基本的に`before_action :authenticate_user`が適応されるようにする

## 変更背景
`/welcome`ページで`before_action :authenticate_user`が実行されてしまいアクセスできなかったため