### PR TITLE
firebaseのrake taskを追加

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -61,5 +61,8 @@ jobs:
       - name: Setup test DB
         run: bundle exec rails db:setup
 
+      - name: Request Firebase Certificates
+        run: bundle exec rails firebase:certificates:force_request
+
       - name: Run tests
         run: bundle exec rspec

--- a/lib/tasks/firebase.rake
+++ b/lib/tasks/firebase.rake
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+namespace :firebase do
+  namespace :certificates do
+    desc "Request Google's x509 certificates when Redis is empty"
+    task request: :environment do
+      FirebaseIdToken::Certificates.request
+    end
+
+    desc "Request Google's x509 certificates and override Redis"
+    task force_request: :environment do
+      FirebaseIdToken::Certificates.request!
+    end
+  end
+end


### PR DESCRIPTION
## やったこと
こちら（https://github.com/fschuindt/firebase_id_token） を参考にx509証明書を取得するタスクを作成し、Heroku Schedulerで1時間ごとに胃jっこうするようにした