### PR TITLE
URLがBOXからはみ出るのを修正

### DIFF
--- a/frontend/src/components/pages/Invitation.tsx
+++ b/frontend/src/components/pages/Invitation.tsx
@@ -34,12 +34,14 @@ export const Invitation: VFC = () => {
           </p>
         </Box>
 
-        <Flex bg="gray.100" p={4} align="center">
-          <Text>{invitationUrl}</Text>
+        <Flex bg="gray.100" py={5} px={6} align="center">
+          <Text flex="1" wordBreak="break-all">
+            {invitationUrl}
+          </Text>
           <CopyToClipboard text={invitationUrl}>
-            <Box onClick={handleFeedback}>
-              <CopyIcon />
-            </Box>
+            <Flex w={10} align="center" justify="flex-end" onClick={handleFeedback}>
+              <CopyIcon w={6} h={6} />
+            </Flex>
           </CopyToClipboard>
         </Flex>
       </Box>


### PR DESCRIPTION
## issue
#163 

## やったこと
URLが長い場合にはみ出てしまうのを修正した

### before
<img width="382" alt="スクリーンショット 2022-02-24 19 14 53" src="https://user-images.githubusercontent.com/52844263/155504738-0bf0a207-37d8-40ef-bce8-e483f63868ea.png">


### after
<img width="383" alt="スクリーンショット 2022-02-24 19 14 40" src="https://user-images.githubusercontent.com/52844263/155504746-6224293d-4507-4b7d-afa1-b65c29ea812b.png">

