### PR TITLE
inputのstateはContextで管理せずそれぞれのコンポーネント内で管理する

### DIFF
--- a/frontend/src/components/pages/NewPaymentEntry.tsx
+++ b/frontend/src/components/pages/NewPaymentEntry.tsx
@@ -1,11 +1,11 @@
-import { useContext, VFC } from 'react'
+import { useState, VFC } from 'react'
 import { useHistory } from 'react-router-dom'
 
 import { Flex, FormControl, FormLabel, Grid, Input } from '@chakra-ui/react'
+import { DateTime } from 'luxon'
 
 import { PrimaryButton } from 'components/atoms/button/PrimaryButton'
 import { HeaderWithTitleLayout } from 'components/templates/HeaderWithTitleLayout'
-import { PaymentContext } from 'context/PaymentContext'
 import { postPayment } from 'lib/api/payment'
 import { auth } from 'lib/firebase'
 import { useToast } from 'lib/toast'
@@ -13,8 +13,9 @@ import { useToast } from 'lib/toast'
 import type { PostPaymentParams } from 'types/postPaymentParams'
 
 export const NewPaymentEntry: VFC = () => {
-  const { inputAmount, setInputAmount, inputDetail, setInputDetail, inputPaidAt, setInputPaidAt } =
-    useContext(PaymentContext)
+  const [inputAmount, setInputAmount] = useState<string>('')
+  const [inputPaidAt, setInputPaidAt] = useState<string>(DateTime.local().toFormat('yyyy-MM-dd'))
+  const [inputDetail, setInputDetail] = useState<string>('')
   const { errorToast, successToast } = useToast()
   const history = useHistory()
 

--- a/frontend/src/components/pages/ShowPaymentEntry.tsx
+++ b/frontend/src/components/pages/ShowPaymentEntry.tsx
@@ -1,4 +1,4 @@
-import { useContext, useEffect, VFC } from 'react'
+import { useContext, useEffect, useState, VFC } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
 
 import { Flex, FormControl, FormLabel, Grid, Input } from '@chakra-ui/react'
@@ -19,16 +19,10 @@ type stateType = {
 }
 
 export const ShowPaymentEntry: VFC = () => {
-  const {
-    inputAmount,
-    setInputAmount,
-    inputDetail,
-    setInputDetail,
-    inputPaidAt,
-    setInputPaidAt,
-    paymentList,
-    setPaymentList,
-  } = useContext(PaymentContext)
+  const { paymentList, setPaymentList } = useContext(PaymentContext)
+  const [inputAmount, setInputAmount] = useState<string>('')
+  const [inputDetail, setInputDetail] = useState<string>('')
+  const [inputPaidAt, setInputPaidAt] = useState<string>('')
   const { errorToast, successToast } = useToast()
   const history = useHistory()
   const location = useLocation()
@@ -68,6 +62,8 @@ export const ShowPaymentEntry: VFC = () => {
       const res = await updatePayment(params, payment.id, idToken)
       if (res.status === 200) {
         setPaymentList(paymentList)
+        setInputAmount('')
+        setInputDetail('')
         onClickClose()
         successToast('支払い情報を更新しました')
       } else {

--- a/frontend/src/context/PaymentContext.ts
+++ b/frontend/src/context/PaymentContext.ts
@@ -4,12 +4,6 @@ import type { PaymentListGroupByPaidAt } from 'types/paymentListGroupByPaidAt'
 import type { TeamStatus } from 'types/teamStatus'
 
 export type PaymentContextType = {
-  inputAmount: string
-  setInputAmount: React.Dispatch<React.SetStateAction<string>>
-  inputDetail: string
-  setInputDetail: React.Dispatch<React.SetStateAction<string>>
-  inputPaidAt: string
-  setInputPaidAt: React.Dispatch<React.SetStateAction<string>>
   paymentList: PaymentListGroupByPaidAt[]
   setPaymentList: React.Dispatch<React.SetStateAction<PaymentListGroupByPaidAt[]>>
   isPaymentListLoaded: boolean
@@ -21,18 +15,6 @@ export type PaymentContextType = {
 }
 
 export const PaymentContext = createContext<PaymentContextType>({
-  inputAmount: '',
-  setInputAmount: () => {
-    throw new Error('PaymentContext not avaliable')
-  },
-  inputDetail: '',
-  setInputDetail: () => {
-    throw new Error('PaymentContext not avaliable')
-  },
-  inputPaidAt: '',
-  setInputPaidAt: () => {
-    throw new Error('PaymentContext not avaliable')
-  },
   paymentList: [],
   setPaymentList: () => {
     throw new Error('PaymentContext not avaliable')

--- a/frontend/src/provider/PaymentProvider.tsx
+++ b/frontend/src/provider/PaymentProvider.tsx
@@ -1,7 +1,5 @@
 import { useContext, useEffect, useState } from 'react'
 
-import { DateTime } from 'luxon'
-
 import { AuthContext } from 'context/AuthContext'
 import { PaymentContext } from 'context/PaymentContext'
 import { getPayments } from 'lib/api/payment'
@@ -24,18 +22,9 @@ export const PaymentProvider = ({ children }: { children: React.ReactElement }) 
   })
   const [isPaymentListLoaded, setIsPaymentListLoaded] = useState<boolean>(false)
   const [isTeamStatusLoaded, setIsTeamStatusLoaded] = useState<boolean>(false)
-  const [inputAmount, setInputAmount] = useState<string>('')
-  const [inputDetail, setInputDetail] = useState<string>('')
-  const [inputPaidAt, setInputPaidAt] = useState<string>(DateTime.local().toFormat('yyyy-MM-dd'))
   const { errorToast } = useToast()
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const value = {
-    inputAmount,
-    setInputAmount,
-    inputDetail,
-    setInputDetail,
-    inputPaidAt,
-    setInputPaidAt,
     paymentList,
     setPaymentList,
     isPaymentListLoaded,


### PR DESCRIPTION
## issue
#150

## やったこと
新規作成画面を開いた際に必ずinputが空になっているようにした

## 修正背景
支払い情報の詳細画面を開いたのち、新規作成画面を開くとひとつ前に開いた支払い情報がセットされてしまっていた
