### PR TITLE
ユーザーのカラーを正しく表示する

### DIFF
--- a/app/views/api/auth/sessions/_user.json.jbuilder
+++ b/app/views/api/auth/sessions/_user.json.jbuilder
@@ -1,6 +1,5 @@
 team = Team.find(user.team_id)
-json.extract! user, :id, :name, :email, :uid, :team_id, :created_at, :updated_at
-json.color user == user.color
+json.extract! user, :id, :name, :email, :uid, :team_id, :created_at, :updated_at, :color
 json.is_debt team.smallest_payment_user == user
 if user.avatar.attached?
   json.avatar do


### PR DESCRIPTION
## issue
#175 

## やったこと
登録時にユーザーの色は正しくセットされていたがフロントに渡す際にcolorカラムの情報がうまくJSONに組み込めていなかったため、ユーザー情報を生成するJSONの構成を変更した

