### PR TITLE
支払い情報を登録・編集・削除した際にPaymenListを再レンダリングする

### DIFF
--- a/frontend/src/components/pages/NewPaymentEntry.tsx
+++ b/frontend/src/components/pages/NewPaymentEntry.tsx
@@ -1,4 +1,4 @@
-import { VFC } from 'react'
+import { useContext, VFC } from 'react'
 import { useForm } from 'react-hook-form'
 import { useHistory } from 'react-router-dom'
 
@@ -7,6 +7,7 @@ import { DateTime } from 'luxon'
 
 import { PrimaryButton } from 'components/atoms/button/PrimaryButton'
 import { HeaderWithTitleLayout } from 'components/templates/HeaderWithTitleLayout'
+import { PaymentContext } from 'context/PaymentContext'
 import { postPayment } from 'lib/api/payment'
 import { auth } from 'lib/firebase'
 import { useToast } from 'lib/toast'
@@ -14,6 +15,7 @@ import { useToast } from 'lib/toast'
 import type { PostPaymentParams } from 'types/postPaymentParams'
 
 export const NewPaymentEntry: VFC = () => {
+  const { updatePaymentList, setUpdatePaymentList } = useContext(PaymentContext)
   const { errorToast, successToast } = useToast()
   const history = useHistory()
   const {
@@ -33,6 +35,7 @@ export const NewPaymentEntry: VFC = () => {
     try {
       const res = await postPayment(params, idToken)
       if (res.status === 200) {
+        setUpdatePaymentList(!updatePaymentList)
         history.push('/')
         successToast('支払い情報を登録しました')
       } else {

--- a/frontend/src/components/pages/ShowPaymentEntry.tsx
+++ b/frontend/src/components/pages/ShowPaymentEntry.tsx
@@ -20,7 +20,7 @@ type stateType = {
 }
 
 export const ShowPaymentEntry: VFC = () => {
-  const { paymentList, setPaymentList } = useContext(PaymentContext)
+  const { updatePaymentList, setUpdatePaymentList } = useContext(PaymentContext)
   const { errorToast, successToast } = useToast()
   const [processingDelete, setProcessingDelete] = useState<boolean>(false)
   const history = useHistory()
@@ -48,7 +48,7 @@ export const ShowPaymentEntry: VFC = () => {
     try {
       const res = await deletePayment(payment.id, idToken)
       if (res.status === 200) {
-        setPaymentList(paymentList)
+        setUpdatePaymentList(!updatePaymentList)
         history.push('/')
         successToast('支払い情報を削除しました')
       } else {
@@ -66,7 +66,7 @@ export const ShowPaymentEntry: VFC = () => {
     try {
       const res = await updatePayment(params, payment.id, idToken)
       if (res.status === 200) {
-        setPaymentList(paymentList)
+        setUpdatePaymentList(!updatePaymentList)
         history.push('/')
         successToast('支払い情報を更新しました')
       } else {

--- a/frontend/src/context/PaymentContext.ts
+++ b/frontend/src/context/PaymentContext.ts
@@ -12,6 +12,8 @@ export type PaymentContextType = {
   setTeamStatus: React.Dispatch<React.SetStateAction<TeamStatus>>
   isTeamStatusLoaded: boolean
   setIsTeamStatusLoaded: React.Dispatch<React.SetStateAction<boolean>>
+  updatePaymentList: boolean
+  setUpdatePaymentList: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export const PaymentContext = createContext<PaymentContextType>({
@@ -35,6 +37,10 @@ export const PaymentContext = createContext<PaymentContextType>({
   },
   isTeamStatusLoaded: false,
   setIsTeamStatusLoaded: () => {
+    throw new Error('PaymentContext not avaliable')
+  },
+  updatePaymentList: false,
+  setUpdatePaymentList: () => {
     throw new Error('PaymentContext not avaliable')
   },
 })

--- a/frontend/src/provider/PaymentProvider.tsx
+++ b/frontend/src/provider/PaymentProvider.tsx
@@ -13,6 +13,7 @@ import type { TeamStatus } from 'types/teamStatus'
 export const PaymentProvider = ({ children }: { children: React.ReactElement }) => {
   const { currentUser } = useContext(AuthContext)
   const [paymentList, setPaymentList] = useState<PaymentListGroupByPaidAt[]>([])
+  const [updatePaymentList, setUpdatePaymentList] = useState<boolean>(false)
   const [teamStatus, setTeamStatus] = useState<TeamStatus>({
     refundAmount: 0,
     largestPaymentUser: null,
@@ -33,6 +34,8 @@ export const PaymentProvider = ({ children }: { children: React.ReactElement }) 
     setTeamStatus,
     isTeamStatusLoaded,
     setIsTeamStatusLoaded,
+    updatePaymentList,
+    setUpdatePaymentList,
   }
 
   const handleGetPayments = async () => {
@@ -72,7 +75,7 @@ export const PaymentProvider = ({ children }: { children: React.ReactElement }) 
       console.log(err)
     })
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [])
+  }, [updatePaymentList])
 
   useEffect(() => {
     handleGetTeamStatus().catch((err) => {


### PR DESCRIPTION
## issue
#155 

## やったこと
支払い情報を登録・編集・削除した際にPaymenListを再レンダリングするようにした
