### PR TITLE
新規登録時の名前にdisplaynameをデフォルトでセットする

### DIFF
--- a/frontend/src/components/pages/Onboarding.tsx
+++ b/frontend/src/components/pages/Onboarding.tsx
@@ -44,6 +44,9 @@ export const Onboarding: VFC = () => {
     formState: { errors },
   } = useForm<CreateUserParams>({
     mode: 'all',
+    defaultValues: {
+      name: auth.currentUser?.displayName,
+    },
   })
 
   const handleImageSelect = (e: React.FormEvent) => {


### PR DESCRIPTION
## issue
#196 

## やったこと
`/onboarding`に遷移した際になまえにデフォルト値をセットする
<img width="345" alt="スクリーンショット 2022-02-27 14 42 20" src="https://user-images.githubusercontent.com/52844263/155869843-1012e252-c178-493b-be20-5663b18bced3.png">


