### PR TITLE
招待URLの遷移先に招待した人の情報を表示する

### DIFF
--- a/app/controllers/api/invitations_controller.rb
+++ b/app/controllers/api/invitations_controller.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+class Api::InvitationsController < Api::ApplicationController
+  skip_before_action :authenticate_user
+
+  def index
+    team = Team.find_by(invitation_token: request.headers[:invitationToken])
+    if team.present?
+      @user = team.users.first
+      render :index
+    else
+      render status: :bad_request
+    end
+  end
+end

--- a/app/views/api/invitations/index.json.jbuilder
+++ b/app/views/api/invitations/index.json.jbuilder
@@ -1,0 +1,7 @@
+if @user
+  json.name @user.name
+  json.avatar do
+    json.data Rails.application.routes.url_helpers.rails_representation_url(@user.avatar.variant(resize: "200x200"))
+    json.name @user.avatar.blob.filename
+  end
+end

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -7,6 +7,8 @@ require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
   # Settings specified here will take precedence over those in config/application.rb.
+  Rails.application.routes.default_url_options[:host] = 'localhost:3001'
+
   config.action_mailer.default_options = { from: 'test@example.com' }
   config.action_mailer.default_url_options = { host: 'localhost:3001' }
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
     resources :users, only: %i[create update]
     resources :sessions, only: %i[index]
     resources :payments
+    resources :invitations, only: %i[index]
     resources :teams, only: %i[show] do
       patch :payments, to: 'teams/payments#update'
     end

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -10,7 +10,7 @@ import { NewPaymentEntry } from 'components/pages/NewPaymentEntry'
 import { Onboarding } from 'components/pages/Onboarding'
 import { Setting } from 'components/pages/Setting'
 import { ShowPaymentEntry } from 'components/pages/ShowPaymentEntry'
-import { Welcome } from 'components/pages/Welcome'
+import { WelcomeWrapper } from 'components/pages/WelcomeWrapper'
 import { PrivateRoute } from 'components/router/PrivateRoute'
 import { AuthProvider } from 'provider/AuthProvider'
 import { PaymentProvider } from 'provider/PaymentProvider'
@@ -20,7 +20,7 @@ const App: VFC = () => (
   <BrowserRouter>
     <ChakraProvider theme={theme}>
       <Switch>
-        <Route path="/welcome" component={Welcome} />
+        <Route path="/welcome" component={WelcomeWrapper} />
         <Route path="/onboarding" component={Onboarding} />
         <Route path="/invitation" component={Invitation} />
         <Route path="/confirmation" component={EmailConfirmation} />

--- a/frontend/src/components/pages/WelcomeWithInvitationToken.tsx
+++ b/frontend/src/components/pages/WelcomeWithInvitationToken.tsx
@@ -1,0 +1,99 @@
+import { VFC, memo, useEffect, useState } from 'react'
+import { useHistory, useLocation } from 'react-router-dom'
+
+import { Box, Button, Flex, Image, Text } from '@chakra-ui/react'
+import { getAuth, signInWithPopup, GoogleAuthProvider } from 'firebase/auth'
+
+import googleIcon from 'assets/images/google_icon.svg'
+import LogoWithCopy from 'assets/images/logo-with-copy.svg'
+import { getInviterName } from 'lib/api/invitation'
+import { getCurrentUser } from 'lib/api/session'
+import { useToast } from 'lib/toast'
+
+export const WelcomeWithInvitationToken: VFC = memo(() => {
+  const history = useHistory()
+  const { search } = useLocation()
+  const query = new URLSearchParams(search)
+  const invitationToken = query.get('invitation_token')
+  const { errorToast } = useToast()
+  const [inviterName, setInviterName] = useState('')
+
+  const handleGetCurrentUser = async () => {
+    const token = await auth.currentUser?.getIdToken(true)
+    const res = await getCurrentUser(token)
+    return res
+  }
+
+  const auth = getAuth()
+  const signInWithGoogle = () => {
+    const provider = new GoogleAuthProvider()
+    signInWithPopup(auth, provider)
+      .then(handleGetCurrentUser)
+      .then((res) => {
+        if (res?.status === 200) {
+          if (res?.data.isExisted) {
+            history.push('/')
+          } else {
+            history.push({
+              pathname: '/onboarding',
+              state: { invitationToken },
+            })
+          }
+        }
+      })
+      .catch((error) => {
+        console.log(error)
+      })
+  }
+
+  const handleGetInviterName = async () => {
+    if (invitationToken) {
+      try {
+        const res = await getInviterName(invitationToken)
+        if (res?.status === 200) {
+          setInviterName(res.data.name)
+        } else {
+          errorToast('不正な招待URLです')
+        }
+      } catch {
+        errorToast('アクセスに失敗しました')
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (invitationToken) {
+      handleGetInviterName().catch((err) => {
+        console.log(err)
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [])
+
+  return (
+    <Flex h="100vh" justify="center" align="center" p={6}>
+      <Box>
+        <Image src={LogoWithCopy} margin="0 auto" mb="14" />
+
+        <Text align="center">
+          下記のボタンをタップして
+          <br />
+          <Text as="span" fontWeight="bold">
+            {inviterName}
+          </Text>
+          さんと
+          <br />
+          seppandaの利用をはじめましょう！
+        </Text>
+
+        <Button onClick={signInWithGoogle} bg="gray.100" size="xl" mb={6} isFullWidth>
+          <Image src={googleIcon} mr={2} />
+          Googleでログインする
+        </Button>
+        <Text fontSize="xs" align="center" color="gray.400">
+          上記のボタンをクリックすることで、利用規約およびプライバシーポリシーに同意するものとします。
+        </Text>
+      </Box>
+    </Flex>
+  )
+})

--- a/frontend/src/components/pages/WelcomeWithInvitationToken.tsx
+++ b/frontend/src/components/pages/WelcomeWithInvitationToken.tsx
@@ -1,12 +1,12 @@
 import { VFC, memo, useEffect, useState } from 'react'
 import { useHistory, useLocation } from 'react-router-dom'
 
-import { Box, Button, Flex, Image, Text } from '@chakra-ui/react'
+import { Box, Button, Heading, Image, Text } from '@chakra-ui/react'
 import { getAuth, signInWithPopup, GoogleAuthProvider } from 'firebase/auth'
 
 import googleIcon from 'assets/images/google_icon.svg'
-import LogoWithCopy from 'assets/images/logo-with-copy.svg'
-import { getInviterName } from 'lib/api/invitation'
+import { HeaderOnlyLogoLayout } from 'components/templates/HeaderOnlyLogoLayout'
+import { getInviter } from 'lib/api/invitation'
 import { getCurrentUser } from 'lib/api/session'
 import { useToast } from 'lib/toast'
 
@@ -17,6 +17,7 @@ export const WelcomeWithInvitationToken: VFC = memo(() => {
   const invitationToken = query.get('invitation_token')
   const { errorToast } = useToast()
   const [inviterName, setInviterName] = useState('')
+  const [inviterAvatar, setInviterAvatar] = useState({ data: '', name: '' })
 
   const handleGetCurrentUser = async () => {
     const token = await auth.currentUser?.getIdToken(true)
@@ -46,12 +47,13 @@ export const WelcomeWithInvitationToken: VFC = memo(() => {
       })
   }
 
-  const handleGetInviterName = async () => {
+  const handleGetInviter = async () => {
     if (invitationToken) {
       try {
-        const res = await getInviterName(invitationToken)
+        const res = await getInviter(invitationToken)
         if (res?.status === 200) {
           setInviterName(res.data.name)
+          setInviterAvatar(res.data.avatar)
         } else {
           errorToast('不正な招待URLです')
         }
@@ -63,7 +65,7 @@ export const WelcomeWithInvitationToken: VFC = memo(() => {
 
   useEffect(() => {
     if (invitationToken) {
-      handleGetInviterName().catch((err) => {
+      handleGetInviter().catch((err) => {
         console.log(err)
       })
     }
@@ -71,29 +73,59 @@ export const WelcomeWithInvitationToken: VFC = memo(() => {
   }, [])
 
   return (
-    <Flex h="100vh" justify="center" align="center" p={6}>
-      <Box>
-        <Image src={LogoWithCopy} margin="0 auto" mb="14" />
-
-        <Text align="center">
-          下記のボタンをタップして
-          <br />
-          <Text as="span" fontWeight="bold">
-            {inviterName}
+    <HeaderOnlyLogoLayout>
+      <Box h="100vh" p={6}>
+        <Box mb={20}>
+          <Heading size="lg" textAlign="center" my={4}>
+            seppandaに参加する
+          </Heading>
+        </Box>
+        <Box bg="gray.100" position="relative" p={6} pt="56px">
+          <Box
+            position="absolute"
+            w="64px"
+            h="64px"
+            top="-32px"
+            left="0"
+            right="0"
+            m="auto"
+            border="2px"
+            borderColor="blue.500"
+            borderRadius="9999px"
+            overflow="hidden"
+          >
+            <Image src={inviterAvatar.data} />
+          </Box>
+          <Text align="center" fontSize="sm" lineHeight="1.8" mb={6}>
+            <Text as="span" fontWeight="bold">
+              {inviterName}
+            </Text>
+            さんが
+            <br />
+            あなたをseppandaの利用に
+            <br />
+            招待しています。
+            <br />
+            下記のボタンから参加しましょう
           </Text>
-          さんと
-          <br />
-          seppandaの利用をはじめましょう！
-        </Text>
 
-        <Button onClick={signInWithGoogle} bg="gray.100" size="xl" mb={6} isFullWidth>
-          <Image src={googleIcon} mr={2} />
-          Googleでログインする
-        </Button>
-        <Text fontSize="xs" align="center" color="gray.400">
-          上記のボタンをクリックすることで、利用規約およびプライバシーポリシーに同意するものとします。
-        </Text>
+          <Button
+            onClick={signInWithGoogle}
+            bg="white"
+            size="xl"
+            mb={6}
+            border="1px solid rgba(46, 47, 46, 0.1)"
+            boxShadow="0px 1px 0px #D7D7D7"
+            isFullWidth
+          >
+            <Image src={googleIcon} mr="24px" />
+            Googleでログインする
+          </Button>
+          <Text fontSize="xs" align="center" color="gray.400">
+            上記のボタンをクリックすることで、利用規約およびプライバシーポリシーに同意するものとします。
+          </Text>
+        </Box>
       </Box>
-    </Flex>
+    </HeaderOnlyLogoLayout>
   )
 })

--- a/frontend/src/components/pages/WelcomeWithInvitationToken.tsx
+++ b/frontend/src/components/pages/WelcomeWithInvitationToken.tsx
@@ -58,7 +58,7 @@ export const WelcomeWithInvitationToken: VFC = memo(() => {
           setIsLoaded(true)
         }
       } catch {
-        history.push('/')
+        history.push('/welcome')
         errorToast('不正な招待URLです')
       }
     }

--- a/frontend/src/components/pages/WelcomeWithInvitationToken.tsx
+++ b/frontend/src/components/pages/WelcomeWithInvitationToken.tsx
@@ -18,6 +18,7 @@ export const WelcomeWithInvitationToken: VFC = memo(() => {
   const { errorToast } = useToast()
   const [inviterName, setInviterName] = useState('')
   const [inviterAvatar, setInviterAvatar] = useState({ data: '', name: '' })
+  const [isLoaded, setIsLoaded] = useState(false)
 
   const handleGetCurrentUser = async () => {
     const token = await auth.currentUser?.getIdToken(true)
@@ -54,11 +55,11 @@ export const WelcomeWithInvitationToken: VFC = memo(() => {
         if (res?.status === 200) {
           setInviterName(res.data.name)
           setInviterAvatar(res.data.avatar)
-        } else {
-          errorToast('不正な招待URLです')
+          setIsLoaded(true)
         }
       } catch {
-        errorToast('アクセスに失敗しました')
+        history.push('/')
+        errorToast('不正な招待URLです')
       }
     }
   }
@@ -71,61 +72,64 @@ export const WelcomeWithInvitationToken: VFC = memo(() => {
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [])
-
   return (
-    <HeaderOnlyLogoLayout>
-      <Box h="100vh" p={6}>
-        <Box mb={20}>
-          <Heading size="lg" textAlign="center" my={4}>
-            seppandaに参加する
-          </Heading>
-        </Box>
-        <Box bg="gray.100" position="relative" p={6} pt="56px">
-          <Box
-            position="absolute"
-            w="64px"
-            h="64px"
-            top="-32px"
-            left="0"
-            right="0"
-            m="auto"
-            border="2px"
-            borderColor="blue.500"
-            borderRadius="9999px"
-            overflow="hidden"
-          >
-            <Image src={inviterAvatar.data} />
-          </Box>
-          <Text align="center" fontSize="sm" lineHeight="1.8" mb={6}>
-            <Text as="span" fontWeight="bold">
-              {inviterName}
-            </Text>
-            さんが
-            <br />
-            あなたをseppandaの利用に
-            <br />
-            招待しています。
-            <br />
-            下記のボタンから参加しましょう
-          </Text>
+    <Box>
+      {isLoaded && (
+        <HeaderOnlyLogoLayout>
+          <Box h="100vh" p={6}>
+            <Box mb={20}>
+              <Heading size="lg" textAlign="center" my={4}>
+                seppandaに参加する
+              </Heading>
+            </Box>
+            <Box bg="gray.100" position="relative" p={6} pt="56px">
+              <Box
+                position="absolute"
+                w="64px"
+                h="64px"
+                top="-32px"
+                left="0"
+                right="0"
+                m="auto"
+                border="2px"
+                borderColor="blue.500"
+                borderRadius="9999px"
+                overflow="hidden"
+              >
+                <Image src={inviterAvatar.data} />
+              </Box>
+              <Text align="center" fontSize="sm" lineHeight="1.8" mb={6}>
+                <Text as="span" fontWeight="bold">
+                  {inviterName}
+                </Text>
+                さんが
+                <br />
+                あなたをseppandaの利用に
+                <br />
+                招待しています。
+                <br />
+                下記のボタンから参加しましょう
+              </Text>
 
-          <Button
-            onClick={signInWithGoogle}
-            bg="white"
-            size="xl"
-            mb={6}
-            border="1px solid rgba(46, 47, 46, 0.1)"
-            boxShadow="0px 1px 0px #D7D7D7"
-            isFullWidth
-          >
-            <Image src={googleIcon} mr="24px" />
-            Googleでログインする
-          </Button>
-          <Text fontSize="xs" align="center" color="gray.400">
-            上記のボタンをクリックすることで、利用規約およびプライバシーポリシーに同意するものとします。
-          </Text>
-        </Box>
-      </Box>
-    </HeaderOnlyLogoLayout>
+              <Button
+                onClick={signInWithGoogle}
+                bg="white"
+                size="xl"
+                mb={6}
+                border="1px solid rgba(46, 47, 46, 0.1)"
+                boxShadow="0px 1px 0px #D7D7D7"
+                isFullWidth
+              >
+                <Image src={googleIcon} mr="24px" />
+                Googleでログインする
+              </Button>
+              <Text fontSize="xs" align="center" color="gray.400">
+                上記のボタンをクリックすることで、利用規約およびプライバシーポリシーに同意するものとします。
+              </Text>
+            </Box>
+          </Box>
+        </HeaderOnlyLogoLayout>
+      )}
+    </Box>
   )
 })

--- a/frontend/src/components/pages/WelcomeWrapper.tsx
+++ b/frontend/src/components/pages/WelcomeWrapper.tsx
@@ -1,0 +1,14 @@
+import { useLocation } from 'react-router-dom'
+
+import { Welcome } from './Welcome'
+import { WelcomeWithInvitationToken } from './WelcomeWithInvitationToken'
+
+export const WelcomeWrapper = () => {
+  const { search } = useLocation()
+  const query = new URLSearchParams(search)
+  const invitationToken = query.get('invitation_token')
+  if (invitationToken) {
+    return <WelcomeWithInvitationToken />
+  }
+  return <Welcome />
+}

--- a/frontend/src/lib/api/invitation.ts
+++ b/frontend/src/lib/api/invitation.ts
@@ -1,0 +1,8 @@
+import { AxiosPromise } from 'axios'
+
+import client from 'lib/api/client'
+
+import type { GetInviterResponse } from 'types/getInviterResponse'
+
+export const getInviter = (invitationToken: string): AxiosPromise<GetInviterResponse> =>
+  client.get('/invitations', { headers: { invitationToken } })

--- a/frontend/src/types/getInviterResponse.ts
+++ b/frontend/src/types/getInviterResponse.ts
@@ -1,0 +1,6 @@
+import type { Avatar } from 'types/avatar'
+
+export type GetInviterResponse = {
+  name: string
+  avatar: Avatar
+}

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -8,5 +8,8 @@ FactoryBot.define do
     trait :with_team do
       association :team
     end
+    after(:build) do |user|
+      user.avatar.attach(io: File.open('spec/fixtures/files/test_user_icon.png'), filename: 'test_user_icon.png', content_type: 'image/png')
+    end
   end
 end

--- a/spec/requests/api/invitations_spec.rb
+++ b/spec/requests/api/invitations_spec.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::Invitations', type: :request do
+  let(:user) { create(:user, :with_team) }
+  let(:invitation_token) { Team.find(user.team_id).invitation_token }
+
+  describe 'GET /api/invitations' do
+    example '正しいinvitation_tokenの場合招待者情報が返る' do
+      get api_invitations_path, headers: { invitationToken: invitation_token }
+      expect(response).to have_http_status(:ok)
+      expect(JSON.parse(response.body)['name']).to be_present
+      expect(JSON.parse(response.body)['avatar']['data']).to be_present
+      expect(JSON.parse(response.body)['avatar']['name']).to be_present
+    end
+
+    example '不正なinvitation_tokenの場合404が返る' do
+      get api_invitations_path, headers: { invitationToken: '12345' }
+      expect(response).to have_http_status(:bad_request)
+    end
+  end
+end


### PR DESCRIPTION
## issue
#153 

## やったこと
招待URLにアクセスした場合に下記のような画面を表示させる。
<img width="362" alt="スクリーンショット 2022-02-27 21 21 45" src="https://user-images.githubusercontent.com/52844263/155882088-13387c5e-2f11-4d5a-91a9-db670065ad40.png">

不正な招待URLだった場合は`/welcome`にリダイレクトする
<img width="358" alt="スクリーンショット 2022-02-27 21 22 55" src="https://user-images.githubusercontent.com/52844263/155882144-9e92ef88-13b1-40a0-9889-864979642727.png">
