### PR TITLE
精算ができないのを修正

### DIFF
--- a/app/controllers/api/teams/payments_controller.rb
+++ b/app/controllers/api/teams/payments_controller.rb
@@ -1,8 +1,6 @@
 # frozen_string_literal: true
 
 class Api::Teams::PaymentsController < Api::ApplicationController
-  before_action :authenticate_api_user!
-
   def update
     payments = Payment.includes(:user).where(team_id: current_user.team_id, settled: false)
     payments.update_all(settled: true, settled_at: Time.zone.now) # rubocop:disable Rails/SkipsModelValidations


### PR DESCRIPTION
## issue
#204 

## やったこと
devise_token_authで使っていた`before_action :authenticate_api_user!`の呼び出しで処理が止まっていたのでそれを削除した

