### PR TITLE
金額入力時数字のみのキーボードを表示する

### DIFF
--- a/frontend/src/components/pages/NewPaymentEntry.tsx
+++ b/frontend/src/components/pages/NewPaymentEntry.tsx
@@ -55,7 +55,7 @@ export const NewPaymentEntry: VFC = () => {
               <FormLabel htmlFor="amount">金額</FormLabel>
               <Input
                 id="amount"
-                type="number"
+                type="tel"
                 size="lg"
                 placeholder="金額を入力"
                 // eslint-disable-next-line react/jsx-props-no-spreading

--- a/frontend/src/components/pages/ShowPaymentEntry.tsx
+++ b/frontend/src/components/pages/ShowPaymentEntry.tsx
@@ -86,7 +86,7 @@ export const ShowPaymentEntry: VFC = () => {
               <FormLabel htmlFor="amount">金額</FormLabel>
               <Input
                 id="amount"
-                type="number"
+                type="tel"
                 size="lg"
                 placeholder="金額を入力"
                 // eslint-disable-next-line react/jsx-props-no-spreading


### PR DESCRIPTION
## issue
#208 


## before
<img src="https://user-images.githubusercontent.com/52844263/155909224-16cee740-ff1a-438c-9468-5281bb9cff53.PNG" width="300">


## after
<img src="https://user-images.githubusercontent.com/52844263/155909234-a4cae338-d15a-4869-9654-4def2a49a9dc.PNG" width="300">
