### PR TITLE
invalid時のinputのスタイルを調整

### DIFF
--- a/frontend/src/theme/components/Input.ts
+++ b/frontend/src/theme/components/Input.ts
@@ -19,6 +19,7 @@ export const Input = {
           borderColor: 'brand.primary',
           boxShadow: 0,
         },
+        _invalid: { borderColor: 'red.500', boxShadow: 'none', _focus: { borderColor: 'red.500' } },
       },
     },
   },


### PR DESCRIPTION
## issue
#212 

## before
borderが太く、エラー状態でfocusするとfocus時のスタイルが重なって表示されていた
<img width="300" alt="スクリーンショット 2022-02-28 10 28 47" src="https://user-images.githubusercontent.com/52844263/155910135-ee60a182-8bda-4fd6-bf9a-7d9a13f4b45f.png"><img width="300" alt="スクリーンショット 2022-02-28 10 28 51" src="https://user-images.githubusercontent.com/52844263/155910050-2250549e-bc23-498a-8cf9-c624c73f06da.png">

## after
エラー時もfocus時と同じborderWidthにし、エラー状態でfocusした場合は赤の線のみを表示するようにした
<img width="412" alt="スクリーンショット 2022-02-28 10 28 15" src="https://user-images.githubusercontent.com/52844263/155910089-a08aaa78-3547-4871-a8a4-b7d77e24d94e.png">


