### PR TITLE
招待URLのモーダルでうまくinvitationTokenが取得できないバグを修正

### DIFF
--- a/frontend/src/components/organisms/modal/InvitationUrlModal.tsx
+++ b/frontend/src/components/organisms/modal/InvitationUrlModal.tsx
@@ -1,6 +1,5 @@
 import { VFC } from 'react'
 import { CopyToClipboard } from 'react-copy-to-clipboard'
-import { useLocation } from 'react-router-dom'
 
 import { CopyIcon } from '@chakra-ui/icons'
 import { Modal, ModalHeader, ModalBody, ModalContent, ModalOverlay, Text, Box, Flex } from '@chakra-ui/react'
@@ -12,17 +11,13 @@ type Props = {
   isOpen: boolean
   onClose: () => void
   size: string
-}
-
-type LocationState = {
   invitationToken: string
 }
 
 export const InvitationUrlModal: VFC<Props> = (props) => {
   const { successToast } = useToast()
-  const { isOpen, onClose, size } = props
-  const location = useLocation<LocationState>()
-  const invitationUrl = `${window.location.protocol}//${window.location.host}/welcome?invitation_token=${location.state.invitationToken}`
+  const { isOpen, onClose, size, invitationToken } = props
+  const invitationUrl = `${window.location.protocol}//${window.location.host}/welcome?invitation_token=${invitationToken}`
 
   const onClickClose = () => {
     onClose()

--- a/frontend/src/components/pages/Home.tsx
+++ b/frontend/src/components/pages/Home.tsx
@@ -23,7 +23,7 @@ export const Home: VFC = memo(() => {
   return (
     <>
       {!localStorage.getItem('invitationUrlClosed') && isTeamStatusLoaded && !teamStatus.isTeamCapacityReached && (
-        <InvitationUrlModal isOpen={isOpen} onClose={onClose} size="xl" />
+        <InvitationUrlModal isOpen={isOpen} onClose={onClose} size="xl" invitationToken={teamStatus.invitationToken} />
       )}
       {isTeamStatusLoaded && !teamStatus.isTeamCapacityReached && (
         <InvitationAlert invitationToken={teamStatus.invitationToken} />

--- a/frontend/src/components/pages/Onboarding.tsx
+++ b/frontend/src/components/pages/Onboarding.tsx
@@ -58,15 +58,8 @@ export const Onboarding: VFC = () => {
     }
     const token = await auth.currentUser?.getIdToken(true)
     try {
-      const res = await createUser(data, token)
-      if (location.state.invitationToken) {
-        history.push('/')
-      } else {
-        history.push({
-          pathname: '/',
-          state: { invitationToken: res.data.invitationToken },
-        })
-      }
+      await createUser(data, token)
+      history.push('/')
       successToast('登録が完了しました')
     } catch (err) {
       if (axios.isAxiosError(err) && (err.response?.data as MultipleErrorResponse).messages) {


### PR DESCRIPTION
## issue
#246 

## 原因
`invitationToken`を前ページか（`/onboarding`）らstateとして渡し、受け取った値を表示していたためうまく受け渡しができていないことがあった

## 解決策
画面上部に固定で出している招待URLと同様に、`teamStatus`に入っている`invitationToken`を取得して表示させる