### PR TITLE
LINEで招待URLを開いた際に外部ブラウザが起動するようにする

### DIFF
--- a/frontend/src/components/organisms/InvitationAlert.tsx
+++ b/frontend/src/components/organisms/InvitationAlert.tsx
@@ -13,7 +13,7 @@ type Props = {
 export const InvitationAlert: FC<Props> = (props) => {
   const { invitationToken } = props
   const { successToast } = useToast()
-  const invitationUrl = `${window.location.protocol}//${window.location.host}/welcome?invitation_token=${invitationToken}`
+  const invitationUrl = `${window.location.protocol}//${window.location.host}/welcome?invitation_token=${invitationToken}&openExternalBrowser=1`
   const handleFeedback = () => {
     successToast('コピーしました')
   }

--- a/frontend/src/components/organisms/modal/InvitationUrlModal.tsx
+++ b/frontend/src/components/organisms/modal/InvitationUrlModal.tsx
@@ -17,7 +17,7 @@ type Props = {
 export const InvitationUrlModal: VFC<Props> = (props) => {
   const { successToast } = useToast()
   const { isOpen, onClose, size, invitationToken } = props
-  const invitationUrl = `${window.location.protocol}//${window.location.host}/welcome?invitation_token=${invitationToken}`
+  const invitationUrl = `${window.location.protocol}//${window.location.host}/welcome?invitation_token=${invitationToken}&openExternalBrowser=1`
 
   const onClickClose = () => {
     onClose()


### PR DESCRIPTION
## issue
#213 

## やったこと
招待URLに`openExternalBrowser=1`を追加し、LINEでURLをタップした際には外部のブラウザが開くようにした
（Twitterやslackなどでは外部ブラウザは起動しないが、Firebase Authの認証は問題なくできる）