### PR TITLE
development環境の時はiatの検証を無効にする

### DIFF
--- a/config/initializers/firebase_id_token/signature.rb
+++ b/config/initializers/firebase_id_token/signature.rb
@@ -1,0 +1,8 @@
+module FirebaseIdToken
+  class Signature
+    # issue: https://github.com/fschuindt/firebase_id_token/issues/21
+    if Rails.env == 'development'
+      JWT_DEFAULTS = { algorithm: 'RS256', verify_iat: false }
+    end
+  end
+end


### PR DESCRIPTION
## issue
#279 

## やったこと
ローカル環境でGoogleサインインを行うとJWTの検証に失敗することがあるため、こちらのissue（https://github.com/fschuindt/firebase_id_token/issues/21）
を参考にdevelopment環境ではiatの検証をしないようにした