### PR TITLE
支払い情報とチームの状態取得のタイミングを調整する

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -3,27 +3,24 @@ import { VFC } from 'react'
 import { Box, ChakraProvider } from '@chakra-ui/react'
 
 import { AuthProvider } from 'providers/AuthProvider'
-import { PaymentProvider } from 'providers/PaymentProvider'
 import { RouterConfig } from 'router/RouterConfig'
 import { theme } from 'theme/index'
 
 const App: VFC = () => (
   <ChakraProvider theme={theme}>
     <AuthProvider>
-      <PaymentProvider>
-        <Box bg={{ base: 'none', sm: 'gray.50' }} minH={{ base: 'none', sm: '100vh' }}>
-          <Box
-            w="100%"
-            m="0 auto"
-            bg="white"
-            maxW={{ base: 'none', sm: '400px' }}
-            minW="320px"
-            minH={{ base: 'none', sm: '100vh' }}
-          >
-            <RouterConfig />
-          </Box>
+      <Box bg={{ base: 'none', sm: 'gray.50' }} minH={{ base: 'none', sm: '100vh' }}>
+        <Box
+          w="100%"
+          m="0 auto"
+          bg="white"
+          maxW={{ base: 'none', sm: '400px' }}
+          minW="320px"
+          minH={{ base: 'none', sm: '100vh' }}
+        >
+          <RouterConfig />
         </Box>
-      </PaymentProvider>
+      </Box>
     </AuthProvider>
   </ChakraProvider>
 )

--- a/frontend/src/context/PaymentContext.ts
+++ b/frontend/src/context/PaymentContext.ts
@@ -12,8 +12,8 @@ export type PaymentContextType = {
   setTeamStatus: React.Dispatch<React.SetStateAction<TeamStatus>>
   isTeamStatusLoaded: boolean
   setIsTeamStatusLoaded: React.Dispatch<React.SetStateAction<boolean>>
-  updatePaymentList: boolean
-  setUpdatePaymentList: React.Dispatch<React.SetStateAction<boolean>>
+  isUpdatedPaymentList: boolean
+  setIsUpdatedPaymentList: React.Dispatch<React.SetStateAction<boolean>>
 }
 
 export const PaymentContext = createContext<PaymentContextType>({
@@ -39,8 +39,8 @@ export const PaymentContext = createContext<PaymentContextType>({
   setIsTeamStatusLoaded: () => {
     throw new Error('PaymentContext not avaliable')
   },
-  updatePaymentList: false,
-  setUpdatePaymentList: () => {
+  isUpdatedPaymentList: false,
+  setIsUpdatedPaymentList: () => {
     throw new Error('PaymentContext not avaliable')
   },
 })

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -1,4 +1,4 @@
-import { memo, useContext, useEffect, VFC } from 'react'
+import { memo, useContext, VFC } from 'react'
 import { Link } from 'react-router-dom'
 
 import { Box, Center, useDisclosure } from '@chakra-ui/react'
@@ -14,68 +14,12 @@ import { PaymentListArea } from 'components/organisms/PaymentListArea'
 import { HomeHeaderLayout } from 'components/templates/HomeHeaderLayout'
 import { AuthContext } from 'context/AuthContext'
 import { PaymentContext } from 'context/PaymentContext'
-import { getPayments } from 'lib/api/payment'
-import { getTeamStatus } from 'lib/api/team'
-import { auth } from 'lib/firebase'
-import { useToast } from 'lib/toast'
 
 export const Home: VFC = memo(() => {
-  const {
-    paymentList,
-    setPaymentList,
-    isPaymentListLoaded,
-    setIsPaymentListLoaded,
-    teamStatus,
-    setTeamStatus,
-    isTeamStatusLoaded,
-    setIsTeamStatusLoaded,
-    updatePaymentList,
-  } = useContext(PaymentContext)
+  const { isPaymentListLoaded, teamStatus, isTeamStatusLoaded } = useContext(PaymentContext)
   const { currentUser } = useContext(AuthContext)
   const { isOpen, onClose } = useDisclosure({ defaultIsOpen: true })
-  const { errorToast } = useToast()
 
-  const handleGetPayments = async () => {
-    setIsPaymentListLoaded(false)
-    const idToken = await auth.currentUser?.getIdToken(true)
-    try {
-      const res = await getPayments(idToken)
-      setPaymentList(res?.data)
-    } catch {
-      errorToast('支払情報の取得ができませんでした', '時間をおいてから再読み込みをしてください')
-    } finally {
-      setIsPaymentListLoaded(true)
-    }
-  }
-
-  const handleGetTeamStatus = async () => {
-    setIsTeamStatusLoaded(false)
-    const idToken = await auth.currentUser?.getIdToken(true)
-    if (currentUser) {
-      try {
-        const res = await getTeamStatus(currentUser.teamId, idToken)
-        setTeamStatus(res?.data)
-      } catch {
-        errorToast('情報の取得に失敗しました', '時間をおいてから再読み込みをしてください')
-      } finally {
-        setIsTeamStatusLoaded(true)
-      }
-    }
-  }
-
-  useEffect(() => {
-    handleGetPayments().catch((err) => {
-      console.log(err)
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [updatePaymentList, currentUser])
-
-  useEffect(() => {
-    handleGetTeamStatus().catch((err) => {
-      console.log(err)
-    })
-    // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [paymentList])
   return (
     <>
       {!localStorage.getItem('invitationUrlClosed') && isTeamStatusLoaded && !teamStatus.isTeamCapacityReached && (

--- a/frontend/src/pages/NewPaymentEntry.tsx
+++ b/frontend/src/pages/NewPaymentEntry.tsx
@@ -17,7 +17,7 @@ import type { PostPaymentParams } from 'types/api/payment'
 import type { MultipleErrorResponse } from 'types/multipleErrorResponses'
 
 export const NewPaymentEntry: VFC = () => {
-  const { updatePaymentList, setUpdatePaymentList } = useContext(PaymentContext)
+  const { isUpdatedPaymentList, setIsUpdatedPaymentList } = useContext(PaymentContext)
   const { errorToast, successToast } = useToast()
   const navigation = useNavigate()
   const {
@@ -36,7 +36,7 @@ export const NewPaymentEntry: VFC = () => {
     const idToken = await auth.currentUser?.getIdToken(true)
     try {
       await postPayment(params, idToken)
-      setUpdatePaymentList(!updatePaymentList)
+      setIsUpdatedPaymentList(!isUpdatedPaymentList)
       navigation('/home')
       successToast('支払い情報を登録しました')
     } catch (err) {

--- a/frontend/src/pages/ShowPaymentEntry.tsx
+++ b/frontend/src/pages/ShowPaymentEntry.tsx
@@ -21,7 +21,7 @@ type stateType = {
 }
 
 export const ShowPaymentEntry: VFC = () => {
-  const { updatePaymentList, setUpdatePaymentList } = useContext(PaymentContext)
+  const { isUpdatedPaymentList, setIsUpdatedPaymentList } = useContext(PaymentContext)
   const { errorToast, successToast } = useToast()
   const [processingDelete, setProcessingDelete] = useState<boolean>(false)
   const navigation = useNavigate()
@@ -48,7 +48,7 @@ export const ShowPaymentEntry: VFC = () => {
     const idToken = await auth.currentUser?.getIdToken(true)
     try {
       await deletePayment(payment.id, idToken)
-      setUpdatePaymentList(!updatePaymentList)
+      setIsUpdatedPaymentList(!isUpdatedPaymentList)
       navigation('/home')
       successToast('支払い情報を削除しました')
     } catch {
@@ -62,7 +62,7 @@ export const ShowPaymentEntry: VFC = () => {
     const idToken = await auth.currentUser?.getIdToken(true)
     try {
       await updatePayment(params, payment.id, idToken)
-      setUpdatePaymentList(!updatePaymentList)
+      setIsUpdatedPaymentList(!isUpdatedPaymentList)
       navigation('/home')
       successToast('支払い情報を更新しました')
     } catch (err) {

--- a/frontend/src/providers/PaymentProvider.tsx
+++ b/frontend/src/providers/PaymentProvider.tsx
@@ -12,7 +12,7 @@ import type { TeamStatus } from 'types/api/team'
 
 export const PaymentProvider = ({ children }: { children: React.ReactElement }) => {
   const [paymentList, setPaymentList] = useState<PaymentListGroupByPaidAt[]>([])
-  const [updatePaymentList, setUpdatePaymentList] = useState<boolean>(false)
+  const [isUpdatedPaymentList, setIsUpdatedPaymentList] = useState<boolean>(false)
   const [teamStatus, setTeamStatus] = useState<TeamStatus>({
     refundAmount: 0,
     largestPaymentUser: null,
@@ -35,8 +35,8 @@ export const PaymentProvider = ({ children }: { children: React.ReactElement }) 
     setTeamStatus,
     isTeamStatusLoaded,
     setIsTeamStatusLoaded,
-    updatePaymentList,
-    setUpdatePaymentList,
+    isUpdatedPaymentList,
+    setIsUpdatedPaymentList,
   }
 
   const handleGetPayments = async () => {
@@ -74,7 +74,7 @@ export const PaymentProvider = ({ children }: { children: React.ReactElement }) 
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [updatePaymentList, currentUser])
+  }, [isUpdatedPaymentList, currentUser])
 
   useEffect(() => {
     if (currentUser) {

--- a/frontend/src/providers/PaymentProvider.tsx
+++ b/frontend/src/providers/PaymentProvider.tsx
@@ -74,7 +74,7 @@ export const PaymentProvider = ({ children }: { children: React.ReactElement }) 
       })
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isUpdatedPaymentList, currentUser])
+  }, [isUpdatedPaymentList])
 
   useEffect(() => {
     if (currentUser) {

--- a/frontend/src/providers/PaymentProvider.tsx
+++ b/frontend/src/providers/PaymentProvider.tsx
@@ -1,6 +1,11 @@
-import { useState } from 'react'
+import { useContext, useEffect, useState } from 'react'
 
+import { AuthContext } from 'context/AuthContext'
 import { PaymentContext } from 'context/PaymentContext'
+import { getPayments } from 'lib/api/payment'
+import { getTeamStatus } from 'lib/api/team'
+import { auth } from 'lib/firebase'
+import { useToast } from 'lib/toast'
 
 import type { PaymentListGroupByPaidAt } from 'types/api/payment'
 import type { TeamStatus } from 'types/api/team'
@@ -17,6 +22,8 @@ export const PaymentProvider = ({ children }: { children: React.ReactElement }) 
   })
   const [isPaymentListLoaded, setIsPaymentListLoaded] = useState<boolean>(false)
   const [isTeamStatusLoaded, setIsTeamStatusLoaded] = useState<boolean>(false)
+  const { errorToast } = useToast()
+  const { currentUser } = useContext(AuthContext)
 
   // eslint-disable-next-line react/jsx-no-constructed-context-values
   const value = {
@@ -31,6 +38,52 @@ export const PaymentProvider = ({ children }: { children: React.ReactElement }) 
     updatePaymentList,
     setUpdatePaymentList,
   }
+
+  const handleGetPayments = async () => {
+    setIsPaymentListLoaded(false)
+    const idToken = await auth.currentUser?.getIdToken(true)
+    try {
+      const res = await getPayments(idToken)
+      setPaymentList(res?.data)
+    } catch {
+      errorToast('支払情報の取得ができませんでした', '時間をおいてから再読み込みをしてください')
+    } finally {
+      setIsPaymentListLoaded(true)
+    }
+  }
+
+  const handleGetTeamStatus = async () => {
+    setIsTeamStatusLoaded(false)
+    const idToken = await auth.currentUser?.getIdToken(true)
+    if (currentUser) {
+      try {
+        const res = await getTeamStatus(currentUser.teamId, idToken)
+        setTeamStatus(res?.data)
+      } catch {
+        errorToast('情報の取得に失敗しました', '時間をおいてから再読み込みをしてください')
+      } finally {
+        setIsTeamStatusLoaded(true)
+      }
+    }
+  }
+
+  useEffect(() => {
+    if (currentUser) {
+      handleGetPayments().catch((err) => {
+        console.log(err)
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [updatePaymentList, currentUser])
+
+  useEffect(() => {
+    if (currentUser) {
+      handleGetTeamStatus().catch((err) => {
+        console.log(err)
+      })
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [paymentList])
 
   return <PaymentContext.Provider value={value}>{children}</PaymentContext.Provider>
 }

--- a/frontend/src/router/PrivateRoute.tsx
+++ b/frontend/src/router/PrivateRoute.tsx
@@ -6,6 +6,7 @@ import { AuthContext } from 'context/AuthContext'
 import { getCurrentUser } from 'lib/api/session'
 import { auth } from 'lib/firebase'
 import { useToast } from 'lib/toast'
+import { PaymentProvider } from 'providers/PaymentProvider'
 
 export const PrivateRoute: VFC = () => {
   const { currentUser, setCurrentUser, currentFirebaseUser, setCurrentFirebaseUser } = useContext(AuthContext)
@@ -49,7 +50,11 @@ export const PrivateRoute: VFC = () => {
 
   if (isLoaded) {
     if (currentUser && currentFirebaseUser) {
-      return <Outlet />
+      return (
+        <PaymentProvider>
+          <Outlet />
+        </PaymentProvider>
+      )
     }
     return <Navigate to="/welcome" />
   }


### PR DESCRIPTION
## issue
#287 

## やったこと
Homeコンポーネント内で支払い情報とチームの状態取得を行なっていたが、これだと設定画面で何もせずHomeに戻ってきた時や、入力画面を開いて何もせずHomeに戻ってきた時もHomeコンポーネントの描画時にリクエストが発生してしまう
（useEffectで初回マウント時のみ実行するようにしていたが、別ページからHomeに戻ってきた時はマウンティングが発生することになるため、Homeを描画する度に処理が走ってしまう。）

従ってHomeコンポーネントよりも上のPaymentProvider内で処理を実行するようにした。