### PR TITLE
細かいスタイルの調整

### DIFF
--- a/frontend/src/components/organisms/InvitationAlert.tsx
+++ b/frontend/src/components/organisms/InvitationAlert.tsx
@@ -20,7 +20,7 @@ export const InvitationAlert: VFC<Props> = memo((props) => {
   return (
     <Box bg="gray.100" p={4} data-testid="invitation-alert">
       <Text fontSize="xs" fontWeight="bold" align="center" mb={3}>
-        お相手の登録がまだのようです
+        おあいての登録がまだのようです
         <br />
         下記のURLを共有して登録をしてもらおう
       </Text>

--- a/frontend/src/components/organisms/PaymentList.tsx
+++ b/frontend/src/components/organisms/PaymentList.tsx
@@ -37,7 +37,7 @@ export const PaymentList: VFC<Props> = memo((props) => {
                 <Box mr={4}>
                   <UserIcon user={payment.user} size="28px" />
                 </Box>
-                <Text flex="1" fontSize="sm">
+                <Text flex="1" fontSize="sm" mr={2}>
                   {payment.detail}
                 </Text>
                 <Flex display="flex" align="baseline" _after={{ content: `"円"`, fontSize: 'xs' }}>

--- a/frontend/src/components/organisms/__test__/InvitationAlert.test.tsx
+++ b/frontend/src/components/organisms/__test__/InvitationAlert.test.tsx
@@ -11,7 +11,7 @@ describe('InvitationAlert', () => {
   it('can render correctly', () => {
     renderWithChakraProvider(<InvitationAlert invitationToken={invitationToken} />)
     expect(screen.getByTestId('invitation-alert')).toHaveTextContent(
-      'お相手の登録がまだのようです下記のURLを共有して登録をしてもらおう'
+      'おあいての登録がまだのようです下記のURLを共有して登録をしてもらおう'
     )
     expect(screen.getByTestId('invitation-alert-invitation-url')).toHaveTextContent(invitationUrl)
   })

--- a/frontend/src/components/organisms/modal/SettlementModal.tsx
+++ b/frontend/src/components/organisms/modal/SettlementModal.tsx
@@ -57,7 +57,7 @@ export const SettelementModal: VFC<Props> = memo((props) => {
         <ModalBody p={0} data-testid="settlement-modal-body">
           <Box mb={12}>
             <Text fontWeight="bold" align="center" mb={6}>
-              お相手に下記の金額を
+              おあいてに下記の金額を
               <br />
               {isDebt ? '返しましたか？' : '返してもらいましたか？'}
             </Text>

--- a/frontend/src/components/organisms/modal/__test__/SettelementModal.test.tsx
+++ b/frontend/src/components/organisms/modal/__test__/SettelementModal.test.tsx
@@ -22,7 +22,7 @@ describe('SettlementModal', () => {
       <SettelementModal teamId={1} refundAmount={refundAmount} isDebt isOpen onClose={onClose} size="xl" />
     )
     expect(screen.getByTestId('settlement-modal')).toBeInTheDocument()
-    expect(screen.getByTestId('settlement-modal-body')).toHaveTextContent('お相手に下記の金額を返しましたか？')
+    expect(screen.getByTestId('settlement-modal-body')).toHaveTextContent('おあいてに下記の金額を返しましたか？')
   })
 
   it('can display correctly when isDebt is false', () => {
@@ -30,7 +30,9 @@ describe('SettlementModal', () => {
       <SettelementModal teamId={1} refundAmount={refundAmount} isDebt={false} isOpen onClose={onClose} size="xl" />
     )
     expect(screen.getByTestId('settlement-modal')).toBeInTheDocument()
-    expect(screen.getByTestId('settlement-modal-body')).toHaveTextContent('お相手に下記の金額を返してもらいましたか？')
+    expect(screen.getByTestId('settlement-modal-body')).toHaveTextContent(
+      'おあいてに下記の金額を返してもらいましたか？'
+    )
   })
 
   it('can close modal', () => {


### PR DESCRIPTION
## やったこと
* 「お相手」をすべて「おあいて」で統一
* 支払い内容と金額の間に余白を設ける