### PR TITLE
横長の画像をセットした時もアイコンサイズが埋まるように拡大し中央でくり抜くようにした

### DIFF
--- a/frontend/src/pages/Setting.tsx
+++ b/frontend/src/pages/Setting.tsx
@@ -102,7 +102,9 @@ export const Setting: VFC = () => {
                   overflow="hidden"
                   bg="gray.50"
                 >
-                  {inputAvatar.data && <Image src={inputAvatar.data} alt={inputAvatar.name} objectFit="cover" />}
+                  {inputAvatar.data && (
+                    <Image src={inputAvatar.data} alt={inputAvatar.name} objectFit="cover" w="94px" h="94px" />
+                  )}
                 </Box>
                 <FormLabel
                   bg="gray.50"


### PR DESCRIPTION
## issue
#314 

## before
<img src="https://user-images.githubusercontent.com/52844263/159614303-995b8818-4ed8-467d-b538-2495f8ba6455.png" width="300">

## after
<img src="https://user-images.githubusercontent.com/52844263/159614318-4c1c9a4d-cfdf-4e2c-a8f8-92981270df33.PNG" width="300">




