### PR TITLE
返してもらう/返すのステータスが常に最新の状態で描画されるようにする

### DIFF
--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -1,6 +1,5 @@
 team = Team.find(user.team_id)
 json.extract! user, :id, :name, :uid, :team_id, :created_at, :updated_at, :color
-json.is_debt team.smallest_payment_user == user
 if user.avatar.attached?
   json.avatar do
     json.data Rails.application.routes.url_helpers.rails_storage_proxy_url(user.avatar.variant(resize: "200x200^", gravity: "center", crop:"200x200+0+0").processed)

--- a/frontend/src/components/atoms/icon/__test__/UserIcon.test.tsx
+++ b/frontend/src/components/atoms/icon/__test__/UserIcon.test.tsx
@@ -18,7 +18,6 @@ describe('SecondaryButton', () => {
       createdAt: '',
       updatedAt: '',
       color: 'blue',
-      isDebt: true,
       avatar: {
         data: IMAGE_URL,
         dataSmall: IMAGE_URL,

--- a/frontend/src/components/organisms/__test__/PaymentList.test.tsx
+++ b/frontend/src/components/organisms/__test__/PaymentList.test.tsx
@@ -17,7 +17,6 @@ const user: User = {
   createdAt: '2022-03-15T10:43:25.863+09:00',
   updatedAt: '2022-03-15T10:43:25.935+09:00',
   color: 'blue',
-  isDebt: false,
   avatar: {
     data: 'https://placekitten.com/200/300',
     dataSmall: 'https://placekitten.com/200/300',

--- a/frontend/src/components/organisms/__test__/PaymentListArea.test.tsx
+++ b/frontend/src/components/organisms/__test__/PaymentListArea.test.tsx
@@ -17,7 +17,6 @@ const user: User = {
   createdAt: '2022-03-15T10:43:25.863+09:00',
   updatedAt: '2022-03-15T10:43:25.935+09:00',
   color: 'blue',
-  isDebt: false,
   avatar: {
     data: 'https://placekitten.com/200/300',
     dataSmall: 'https://placekitten.com/200/300',

--- a/frontend/src/pages/Home.tsx
+++ b/frontend/src/pages/Home.tsx
@@ -38,7 +38,7 @@ export const Home: VFC = memo(() => {
           <HomeHeaderLayout>
             <CurrentStatusCard
               isLoaded={isTeamStatusLoaded}
-              isDebt={currentUser.isDebt}
+              isDebt={teamStatus.smallestPaymentUser?.uid === currentUser.uid}
               refundAmount={teamStatus.refundAmount}
               teamId={currentUser.teamId}
               isTeamCapacityReached={teamStatus.isTeamCapacityReached}

--- a/frontend/src/types/user.ts
+++ b/frontend/src/types/user.ts
@@ -9,5 +9,4 @@ export type User = {
   updatedAt: string
   avatar: Avatar
   color: string
-  isDebt: boolean
 }


### PR DESCRIPTION
## issue
#335 

## やったこと
返してもらう/返すの表示切り替えを`currentUser`の`isDebt`プロパティではなく、`PaymentProvider`の`smallestPaymentUser`で判別するようにした
