### PR TITLE
支払い情報の編集・削除を自分が所属するチーム以外に対して行えないようにする

### DIFF
--- a/app/controllers/api/payments_controller.rb
+++ b/app/controllers/api/payments_controller.rb
@@ -38,6 +38,6 @@ class API::PaymentsController < API::ApplicationController
   end
 
   def set_payment
-    @payment = Payment.find(params[:id])
+    @payment = current_user.team.payments.find(params[:id])
   end
 end


### PR DESCRIPTION
## issue
#330

## やったこと
* 自分が所属するチーム以外の支払い情報を編集・削除できないようにしました
    * 自分が登録した支払い情報以外は編集・削除できないようにしてもいいのですが、今回のアプリの場合カップルやふうふなどかなり親密な間柄で使うアプリのためお互いの情報は編集できても問題ないと考えており、元々相手の支払い情報を編集・削除できるような仕様にしていたためそれに則って実装しました
