### PR TITLE
一度精算済みで片方のみが新規で支払い情報を登録している状態でも正しく集計が行われるように修正

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -39,7 +39,10 @@ class Team < ApplicationRecord
   private
 
   def user_id_and_total_amount
-    users.left_joins(:payments).group('users.id').where(payments: { settled: [nil, false] }).sum('payments.amount')
+    users
+      .left_joins(:payments)
+      .group('users.id')
+      .sum('CASE WHEN payments.settled = FALSE OR payments.settled IS NULL THEN payments.amount ELSE 0 END')
   end
 
   def first_user_unsettled_total_amount

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -21,11 +21,11 @@ class Team < ApplicationRecord
   end
 
   def largest_payment_user
-    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.max)) unless refund_amount.zero?
+    users.find(user_id_and_total_amount.key(user_id_and_total_amount.values.max)) unless refund_amount.zero?
   end
 
   def smallest_payment_user
-    User.find(user_id_and_total_amount.key(user_id_and_total_amount.values.min)) unless refund_amount.zero?
+    users.find(user_id_and_total_amount.key(user_id_and_total_amount.values.min)) unless refund_amount.zero?
   end
 
   def capacity_reached?

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -27,6 +27,13 @@ RSpec.describe Team, type: :model do
         other_user.payments.create(amount: 200, detail: '日用品', team_id: team.id, paid_at: '2022-02-25')
       end
 
+      # TODO: 本来はprivateメソッドは直接テストすべきではないためテストケースの整理も含めて後ほど設計を見直す
+      example '#user_id_and_total_amount' do
+        ret = team.send(:user_id_and_total_amount)
+        expect(ret.size).to eq 2
+        expect(ret).to eq({ host_user.id => 800, other_user.id => 200 })
+      end
+
       example '各ユーザーの支払い合計金額' do
         expect(host_user.payments.sum(:amount)).to eq 1000
         expect(other_user.payments.sum(:amount)).to eq 500
@@ -63,6 +70,13 @@ RSpec.describe Team, type: :model do
         host_user.payments.create(amount: 200, detail: '外食', team_id: team.id, paid_at: '2022-02-14', settled: true, settled_at: '2022-02-24')
         host_user.payments.create(amount: 800, detail: 'スーパー', team_id: team.id, paid_at: '2022-02-25')
         other_user.payments.create(amount: 300, detail: 'カフェ', team_id: team.id, paid_at: '2022-02-14', settled: true, settled_at: '2022-02-24')
+      end
+
+      # TODO: 本来はprivateメソッドは直接テストすべきではないためテストケースの整理も含めて後ほど設計を見直す
+      example '#user_id_and_total_amount' do
+        ret = team.send(:user_id_and_total_amount)
+        expect(ret.size).to eq 2
+        expect(ret).to eq({ host_user.id => 800, other_user.id => 0 })
       end
 
       example '各ユーザーの支払い合計金額' do
@@ -104,6 +118,13 @@ RSpec.describe Team, type: :model do
         other_user.payments.create(amount: 300, detail: 'カフェ', team_id: team.id, paid_at: '2022-02-14', settled: true, settled_at: '2022-02-24')
         other_user.payments.create(amount: 500, detail: '日用品', team_id: team.id, paid_at: '2022-02-25')
         other_user.payments.create(amount: 500, detail: 'おやつ', team_id: team.id, paid_at: '2022-02-25')
+      end
+
+      # TODO: 本来はprivateメソッドは直接テストすべきではないためテストケースの整理も含めて後ほど設計を見直す
+      example '#user_id_and_total_amount' do
+        ret = team.send(:user_id_and_total_amount)
+        expect(ret.size).to eq 2
+        expect(ret).to eq({ host_user.id => 1000, other_user.id => 1000 })
       end
 
       example '各ユーザーの支払い合計金額' do

--- a/spec/models/team_spec.rb
+++ b/spec/models/team_spec.rb
@@ -41,19 +41,57 @@ RSpec.describe Team, type: :model do
         expect(team.unsettled_total_amount).to eq 1000
       end
 
-      example '1人あたり支払うべき金額' do
+      example '1人あたり支払うべき金額（split_bill_amount）' do
         expect(team.split_bill_amount).to eq 500
       end
 
-      example '返金額' do
+      example '返金額（refund_amount）' do
         expect(team.refund_amount).to eq 300
       end
 
-      example '一人当たり支払うべき金額より多く支払っているユーザー' do
+      example '一人当たり支払うべき金額より多く支払っているユーザー（largest_payment_user）' do
         expect(team.largest_payment_user).to eq host_user
       end
 
-      example '一人当たり支払うべき金額より支払いが少ないユーザー' do
+      example '一人当たり支払うべき金額より支払いが少ないユーザー（smallest_payment_user）' do
+        expect(team.smallest_payment_user).to eq other_user
+      end
+    end
+
+    context '一度精算済みで片方のみ新たに支払いを登録している場合' do
+      before do
+        host_user.payments.create(amount: 200, detail: '外食', team_id: team.id, paid_at: '2022-02-14', settled: true, settled_at: '2022-02-24')
+        host_user.payments.create(amount: 800, detail: 'スーパー', team_id: team.id, paid_at: '2022-02-25')
+        other_user.payments.create(amount: 300, detail: 'カフェ', team_id: team.id, paid_at: '2022-02-14', settled: true, settled_at: '2022-02-24')
+      end
+
+      example '各ユーザーの支払い合計金額' do
+        expect(host_user.payments.sum(:amount)).to eq 1000
+        expect(other_user.payments.sum(:amount)).to eq 300
+      end
+
+      example '各ユーザーの未精算支払い合計金額' do
+        expect(host_user.payments.unsettled.sum(:amount)).to eq 800
+        expect(other_user.payments.unsettled.sum(:amount)).to eq 0
+      end
+
+      example 'teamの未清算支払い合計金額' do
+        expect(team.unsettled_total_amount).to eq 800
+      end
+
+      example '1人あたり支払うべき金額（split_bill_amount）' do
+        expect(team.split_bill_amount).to eq 400
+      end
+
+      example '返金額（refund_amount）' do
+        expect(team.refund_amount).to eq 400
+      end
+
+      example '一人当たり支払うべき金額より多く支払っているユーザー（largest_payment_user）' do
+        expect(team.largest_payment_user).to eq host_user
+      end
+
+      example '一人当たり支払うべき金額より支払いが少ないユーザー（smallest_payment_user）' do
         expect(team.smallest_payment_user).to eq other_user
       end
     end
@@ -77,19 +115,19 @@ RSpec.describe Team, type: :model do
         expect(host_user.payments.unsettled.sum(:amount)).to eq other_user.payments.unsettled.sum(:amount)
       end
 
-      example '1人あたり支払うべき金額' do
+      example '1人あたり支払うべき金額（split_bill_amount）' do
         expect(team.split_bill_amount).to eq 1000
       end
 
-      example '返金額' do
+      example '返金額（refund_amount）' do
         expect(team.refund_amount).to eq 0
       end
 
-      example '一人当たり支払うべき金額より多く支払っているユーザー' do
+      example '一人当たり支払うべき金額より多く支払っているユーザー（largest_payment_user）' do
         expect(team.largest_payment_user).to eq nil
       end
 
-      example '一人当たり支払うべき金額より支払いが少ないユーザー' do
+      example '一人当たり支払うべき金額より支払いが少ないユーザー（smallest_payment_user）' do
         expect(team.smallest_payment_user).to eq nil
       end
     end
@@ -109,19 +147,19 @@ RSpec.describe Team, type: :model do
         expect(team.unsettled_total_amount).to eq 0
       end
 
-      example '1人あたり支払うべき金額' do
+      example '1人あたり支払うべき金額（split_bill_amount）' do
         expect(team.split_bill_amount).to eq 0
       end
 
-      example '返金額' do
+      example '返金額（refund_amount）' do
         expect(team.refund_amount).to eq 0
       end
 
-      example '一人当たり支払うべき金額より多く支払っているユーザー' do
+      example '一人当たり支払うべき金額より多く支払っているユーザー（largest_payment_user）' do
         expect(team.largest_payment_user).to eq nil
       end
 
-      example '一人当たり支払うべき金額より支払いが少ないユーザー' do
+      example '一人当たり支払うべき金額より支払いが少ないユーザー（smallest_payment_user）' do
         expect(team.smallest_payment_user).to eq nil
       end
     end


### PR DESCRIPTION
## issue
#342 

## やったこと
ユーザーから問い合わせのあった「返す」「返してもらう」の表記が正しく表示されないバグについての修正を行った。
* `user_id_and_total_amount`を実行した際に、片方が支払い情報を登録していなくても必ず`{user_id=>amount, user_id=>amount}`の形で集計されるようにした

## 申し送り事項
一時的にprivateメソッドである`user_id_and_total_amount`についてのテストを追加しているが、本来praivateメソッドのテストは直接テストすべきでないため後ほど設計を見直す
