### PR TITLE
バックエンドで画像の処理を行わない

### DIFF
--- a/app/views/api/invitations/index.json.jbuilder
+++ b/app/views/api/invitations/index.json.jbuilder
@@ -1,7 +1,7 @@
 if @user
   json.name @user.name
   json.avatar do
-    json.data Rails.application.routes.url_helpers.rails_storage_proxy_url(@user.avatar.variant(resize: "100x100^", gravity: "center", crop:"100x100+0+0").processed)
+    json.data Rails.application.routes.url_helpers.rails_storage_proxy_url(@user.avatar)
     json.name @user.avatar.blob.filename
   end
 end

--- a/app/views/api/users/_user.json.jbuilder
+++ b/app/views/api/users/_user.json.jbuilder
@@ -2,8 +2,8 @@ team = Team.find(user.team_id)
 json.extract! user, :id, :name, :uid, :team_id, :created_at, :updated_at, :color
 if user.avatar.attached?
   json.avatar do
-    json.data Rails.application.routes.url_helpers.rails_storage_proxy_url(user.avatar.variant(resize: "200x200^", gravity: "center", crop:"200x200+0+0").processed)
-    json.data_small Rails.application.routes.url_helpers.rails_storage_proxy_url(user.avatar.variant(resize: "40x40^", gravity: "center", crop:"40x40+0+0").processed)
+    json.data Rails.application.routes.url_helpers.rails_storage_proxy_url(user.avatar)
+    json.data_small Rails.application.routes.url_helpers.rails_storage_proxy_url(user.avatar)
     json.name user.avatar.blob.filename
   end
 end


### PR DESCRIPTION
Minimagickによる画像の処理でエラーが発生し、ログインができないケースがあるため
バックエンドでの処理を外す。（フロント側で圧縮処理は実施しているため）