### PR TITLE
ログアウト後ページをリロードする

### DIFF
--- a/frontend/src/pages/Setting.tsx
+++ b/frontend/src/pages/Setting.tsx
@@ -76,6 +76,7 @@ export const Setting: VFC = () => {
   const handleSignOut = async () => {
     await signOut(auth)
     navigation('/')
+    window.location.reload()
     successToast('ログアウトしました')
   }
 


### PR DESCRIPTION
## 概要
ログアウトボタンをタップして`/`に遷移したあと再度ログインボタンをタップすると
エラーが発生してしまっていたのを修正した


